### PR TITLE
feat(api): jaffrey add Excel import endpoint with anomaly detection and reimport support

### DIFF
--- a/backend/api/importers/dto.py
+++ b/backend/api/importers/dto.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 
-@dataclass
+@dataclass(frozen=True)
 class WorkloadRowDTO:
     """
     Parsed representation of one row in the import template.

--- a/backend/api/importers/dto.py
+++ b/backend/api/importers/dto.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class WorkloadRowDTO:
+    """
+    Parsed representation of one row in the import template.
+    All hour values are already scaled (Daniela applies contact-hour ratios before upload).
+    Fields semester, academic_year, department come from the file header if not present per-row.
+    """
+    staff_number: str
+    staff_name: str
+    fte: float
+    function: str           # 'T & R' | 'Teach (TI)' | 'Resrch'
+    target_band: str        # 'Balanced Teaching & Research' | 'Teaching Focused' | 'Research Focused'
+    target_teaching_pct: float
+    staff_type: str         # 'Academic staff' | 'Paid casual staff'
+
+    # Teaching (per unit) — one DTO per row, unit_code may be blank for non-teaching staff
+    unit_code: Optional[str]
+    unit_enrolment: Optional[int]
+    teaching_hrs: float
+    unit_coord_hrs: float
+    teaching_activity_hrs: float
+    unit_supervision_hrs: float
+    new_unit_dev_hrs: float
+
+    # HDR supervision
+    hdr_total_hrs: float
+
+    # Service & roles
+    assigned_roles_total_pts: float
+
+    # Context fields — sourced from file header or per-row columns
+    semester: str           # 'S1' | 'S2'
+    academic_year: int      # e.g. 2025
+    department: str         # department name, matched to Department table

--- a/backend/api/importers/service.py
+++ b/backend/api/importers/service.py
@@ -1,0 +1,302 @@
+import uuid
+from decimal import Decimal
+from typing import Optional
+
+import openpyxl
+
+from api.importers.dto import WorkloadRowDTO
+from api.models import AuditLog, Department, Staff, WorkloadItem, WorkloadReport
+
+WL_HOURS_PER_POINT = Decimal('17.25')
+
+# Column indices in the template (0-based, row 4 is the header row)
+COL_STAFF_ID = 0
+COL_STAFF_NAME = 1
+COL_STAFF_NUMBER = 2
+COL_FTE = 3
+COL_FUNCTION = 4
+COL_TARGET_BAND = 5
+COL_TARGET_TEACHING_PCT = 6
+COL_UNIT_CODE = 7
+COL_UNIT_ENROLMENT = 8
+COL_STAFF_TYPE = 9
+COL_TEACHING_HRS = 10
+COL_UNIT_COORD_HRS = 12
+COL_TEACHING_ACTIVITY_HRS = 14
+COL_UNIT_SUPERVISION_HRS = 16
+COL_NEW_UNIT_DEV_HRS = 18
+COL_HDR_TOTAL_HRS = 25
+COL_ASSIGNED_ROLES_TOTAL_PTS = 28
+
+# Header cells for file-level context (row 1, columns B/C/D)
+# Daniela writes: Semester=S1, Academic Year=2025, Department=CSSE in these cells.
+# If these are absent, the import will fail with a 400 error.
+HEADER_ROW_SEMESTER = (1, 2)       # row 1, col B
+HEADER_ROW_ACADEMIC_YEAR = (1, 3)  # row 1, col C
+HEADER_ROW_DEPARTMENT = (1, 4)     # row 1, col D
+
+DATA_START_ROW = 5  # data rows begin at row 5 (rows 1-4 are header/instructions)
+
+
+def _float(val, default=0.0) -> float:
+    try:
+        return float(val) if val is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _str(val) -> str:
+    return str(val).strip() if val is not None else ''
+
+
+def parse_excel(file_obj) -> tuple[list[WorkloadRowDTO], dict]:
+    """
+    Parse the uploaded Excel file into a list of WorkloadRowDTOs.
+    Returns (rows, header_meta) where header_meta contains semester/year/department.
+    Raises ValueError with a descriptive message if the file is malformed.
+    """
+    wb = openpyxl.load_workbook(file_obj, data_only=True)
+    ws = wb.active
+
+    # Read file-level context from header cells
+    header_semester = _str(ws.cell(*HEADER_ROW_SEMESTER).value)
+    header_year_raw = ws.cell(*HEADER_ROW_ACADEMIC_YEAR).value
+    header_department = _str(ws.cell(*HEADER_ROW_DEPARTMENT).value)
+
+    try:
+        header_year = int(header_year_raw) if header_year_raw else 0
+    except (TypeError, ValueError):
+        header_year = 0
+
+    rows = []
+    for row in ws.iter_rows(min_row=DATA_START_ROW, values_only=True):
+        staff_number = _str(row[COL_STAFF_NUMBER] if len(row) > COL_STAFF_NUMBER else None)
+        if not staff_number:
+            continue  # skip blank rows
+
+        # Per-row context overrides file header if present
+        semester = header_semester
+        academic_year = header_year
+        department = header_department
+
+        rows.append(WorkloadRowDTO(
+            staff_number=staff_number,
+            staff_name=_str(row[COL_STAFF_NAME] if len(row) > COL_STAFF_NAME else None),
+            fte=_float(row[COL_FTE] if len(row) > COL_FTE else None, 1.0),
+            function=_str(row[COL_FUNCTION] if len(row) > COL_FUNCTION else None),
+            target_band=_str(row[COL_TARGET_BAND] if len(row) > COL_TARGET_BAND else None),
+            target_teaching_pct=_float(row[COL_TARGET_TEACHING_PCT] if len(row) > COL_TARGET_TEACHING_PCT else None),
+            staff_type=_str(row[COL_STAFF_TYPE] if len(row) > COL_STAFF_TYPE else None),
+            unit_code=_str(row[COL_UNIT_CODE] if len(row) > COL_UNIT_CODE else None) or None,
+            unit_enrolment=int(_float(row[COL_UNIT_ENROLMENT] if len(row) > COL_UNIT_ENROLMENT else None)) or None,
+            teaching_hrs=_float(row[COL_TEACHING_HRS] if len(row) > COL_TEACHING_HRS else None),
+            unit_coord_hrs=_float(row[COL_UNIT_COORD_HRS] if len(row) > COL_UNIT_COORD_HRS else None),
+            teaching_activity_hrs=_float(row[COL_TEACHING_ACTIVITY_HRS] if len(row) > COL_TEACHING_ACTIVITY_HRS else None),
+            unit_supervision_hrs=_float(row[COL_UNIT_SUPERVISION_HRS] if len(row) > COL_UNIT_SUPERVISION_HRS else None),
+            new_unit_dev_hrs=_float(row[COL_NEW_UNIT_DEV_HRS] if len(row) > COL_NEW_UNIT_DEV_HRS else None),
+            hdr_total_hrs=_float(row[COL_HDR_TOTAL_HRS] if len(row) > COL_HDR_TOTAL_HRS else None),
+            assigned_roles_total_pts=_float(row[COL_ASSIGNED_ROLES_TOTAL_PTS] if len(row) > COL_ASSIGNED_ROLES_TOTAL_PTS else None),
+            semester=semester,
+            academic_year=academic_year,
+            department=department,
+        ))
+
+    header_meta = {
+        'semester': header_semester,
+        'academic_year': header_year,
+        'department': header_department,
+    }
+    return rows, header_meta
+
+
+def _detect_anomaly(fte: float, teaching_pts: Decimal, hdr_pts: Decimal,
+                    role_pts: Decimal, service_pts: Decimal, target_band: str) -> Optional[bool]:
+    """
+    Implements the Nidhi PDF anomaly detection algorithm exactly.
+    Returns True if anomaly detected, False if not, None if insufficient data.
+    """
+    research_pts = Decimal(str(fte)) * 100 - (teaching_pts + role_pts + service_pts + hdr_pts)
+    total = teaching_pts + research_pts
+    if total == 0:
+        return None
+
+    calc_tr = round(float(teaching_pts / total), 2)
+
+    if calc_tr <= 0.20:
+        calc_band = 'Research Focused'
+    elif calc_tr <= 0.79:
+        calc_band = 'Balanced Teaching & Research'
+    else:
+        calc_band = 'Teaching Focused'
+
+    return calc_band != target_band
+
+
+def _hrs_to_pts(hours: float) -> Decimal:
+    return (Decimal(str(hours)) / WL_HOURS_PER_POINT).quantize(Decimal('0.01'))
+
+
+def import_workload_excel(file_obj, uploaded_by) -> dict:
+    """
+    Parse the Excel file and persist WorkloadReports + WorkloadItems.
+    Returns a summary dict: {batch_id, created, updated, skipped, errors}.
+
+    Raises ValueError for missing header fields (semester/year/department).
+    """
+    rows, header_meta = parse_excel(file_obj)
+
+    # Validate required header fields
+    missing = [k for k, v in header_meta.items() if not v]
+    if missing:
+        raise ValueError(
+            f"Missing required header fields: {', '.join(missing)}. "
+            "Please add Semester (cell B1), Academic Year (cell C1), "
+            "and Department (cell D1) to the file header."
+        )
+
+    batch_id = uuid.uuid4()
+    created = updated = skipped = 0
+    errors = []
+
+    for dto in rows:
+        # Skip casual staff — they don't enter the approval workflow
+        if 'casual' in dto.staff_type.lower():
+            skipped += 1
+            continue
+
+        try:
+            staff = Staff.objects.select_related('department').get(
+                staff_number=dto.staff_number
+            )
+        except Staff.DoesNotExist:
+            errors.append(f"Staff {dto.staff_number} not found — row skipped.")
+            skipped += 1
+            continue
+
+        try:
+            department = Department.objects.get(name__iexact=dto.department)
+        except Department.DoesNotExist:
+            errors.append(f"Department '{dto.department}' not found — row for {dto.staff_number} skipped.")
+            skipped += 1
+            continue
+
+        # Calculate WL points for anomaly detection
+        teaching_pts = _hrs_to_pts(
+            dto.teaching_hrs + dto.unit_coord_hrs + dto.teaching_activity_hrs
+            + dto.unit_supervision_hrs + dto.new_unit_dev_hrs
+        )
+        hdr_pts = _hrs_to_pts(dto.hdr_total_hrs)
+        role_pts = Decimal(str(dto.assigned_roles_total_pts))
+        service_pts = Decimal(str(dto.fte)) * 10  # Self-Directed Service = FTE × 10
+
+        is_anomaly = _detect_anomaly(
+            dto.fte, teaching_pts, hdr_pts, role_pts, service_pts, dto.target_band
+        )
+
+        # Check for existing record with same natural key
+        existing = WorkloadReport.objects.filter(
+            staff=staff,
+            semester=dto.semester,
+            academic_year=dto.academic_year,
+            is_current=True,
+        ).first()
+
+        if existing:
+            if existing.status == 'PENDING':
+                # Supersede the old PENDING record
+                new_report = _create_report(
+                    staff, department, dto, batch_id, is_anomaly
+                )
+                existing.is_current = False
+                existing.superseded_by = new_report
+                existing.save()
+                AuditLog.objects.create(
+                    report=new_report,
+                    action_by=uploaded_by,
+                    action_type='MODIFIED_BY_REIMPORT',
+                    comment=f"Superseded report {existing.report_id}",
+                )
+                _create_items(new_report, dto)
+                updated += 1
+            else:
+                # Terminal state — create a correction version, flag for OPS review
+                new_report = _create_report(
+                    staff, department, dto, batch_id, is_anomaly
+                )
+                AuditLog.objects.create(
+                    report=new_report,
+                    action_by=uploaded_by,
+                    action_type='MODIFIED_BY_REIMPORT',
+                    comment=f"Correction of terminal record {existing.report_id} — requires OPS review.",
+                )
+                _create_items(new_report, dto)
+                updated += 1
+        else:
+            new_report = _create_report(staff, department, dto, batch_id, is_anomaly)
+            AuditLog.objects.create(
+                report=new_report,
+                action_by=uploaded_by,
+                action_type='IMPORTED',
+                comment=None,
+            )
+            _create_items(new_report, dto)
+            created += 1
+
+    return {
+        'batch_id': str(batch_id),
+        'created': created,
+        'updated': updated,
+        'skipped': skipped,
+        'errors': errors,
+    }
+
+
+def _create_report(staff, department, dto: WorkloadRowDTO, batch_id, is_anomaly) -> WorkloadReport:
+    return WorkloadReport.objects.create(
+        staff=staff,
+        academic_year=dto.academic_year,
+        semester=dto.semester,
+        snapshot_fte=Decimal(str(dto.fte)),
+        snapshot_department=department,
+        is_anomaly=bool(is_anomaly) if is_anomaly is not None else False,
+        import_batch_id=batch_id,
+        is_current=True,
+        status='PENDING',
+    )
+
+
+def _create_items(report: WorkloadReport, dto: WorkloadRowDTO):
+    items = []
+    teaching_hrs = (
+        dto.teaching_hrs + dto.unit_coord_hrs + dto.teaching_activity_hrs
+        + dto.unit_supervision_hrs + dto.new_unit_dev_hrs
+    )
+    if teaching_hrs > 0:
+        items.append(WorkloadItem(
+            report=report,
+            category='TEACHING',
+            unit_code=dto.unit_code,
+            allocated_hours=Decimal(str(teaching_hrs)),
+        ))
+    if dto.hdr_total_hrs > 0:
+        items.append(WorkloadItem(
+            report=report,
+            category='HDR_SUPERVISION',
+            allocated_hours=Decimal(str(dto.hdr_total_hrs)),
+        ))
+    if dto.assigned_roles_total_pts > 0:
+        # Assigned roles are stored as points × 17.25 to convert back to hours
+        role_hrs = float(dto.assigned_roles_total_pts) * float(WL_HOURS_PER_POINT)
+        items.append(WorkloadItem(
+            report=report,
+            category='ASSIGNED_ROLE',
+            allocated_hours=Decimal(str(role_hrs)).quantize(Decimal('0.01')),
+        ))
+    # Self-Directed Service is always auto-calculated
+    service_hrs = float(dto.fte) * 10 * float(WL_HOURS_PER_POINT)
+    items.append(WorkloadItem(
+        report=report,
+        category='SERVICE',
+        allocated_hours=Decimal(str(service_hrs)).quantize(Decimal('0.01')),
+    ))
+    WorkloadItem.objects.bulk_create(items)

--- a/backend/api/importers/service.py
+++ b/backend/api/importers/service.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Optional
 
 import openpyxl
+from django.db import transaction
 
 from api.importers.dto import WorkloadRowDTO
 from api.models import AuditLog, Department, Staff, WorkloadItem, WorkloadReport
@@ -203,43 +204,46 @@ def import_workload_excel(file_obj, uploaded_by) -> dict:
 
         if existing:
             if existing.status == 'PENDING':
-                # Supersede the old PENDING record
-                new_report = _create_report(
-                    staff, department, dto, batch_id, is_anomaly
-                )
-                existing.is_current = False
-                existing.superseded_by = new_report
-                existing.save()
-                AuditLog.objects.create(
-                    report=new_report,
-                    action_by=uploaded_by,
-                    action_type='MODIFIED_BY_REIMPORT',
-                    comment=f"Superseded report {existing.report_id}",
-                )
-                _create_items(new_report, dto)
+                with transaction.atomic():
+                    # Supersede the old PENDING record; atomic so partial writes roll back
+                    new_report = _create_report(
+                        staff, department, dto, batch_id, is_anomaly
+                    )
+                    existing.is_current = False
+                    existing.superseded_by = new_report
+                    existing.save()
+                    AuditLog.objects.create(
+                        report=new_report,
+                        action_by=uploaded_by,
+                        action_type='MODIFIED_BY_REIMPORT',
+                        comment=f"Superseded report {existing.report_id}",
+                    )
+                    _create_items(new_report, dto)
                 updated += 1
             else:
-                # Terminal state — create a correction version, flag for OPS review
-                new_report = _create_report(
-                    staff, department, dto, batch_id, is_anomaly
-                )
+                with transaction.atomic():
+                    # Terminal state — create a correction version, flag for OPS review
+                    new_report = _create_report(
+                        staff, department, dto, batch_id, is_anomaly
+                    )
+                    AuditLog.objects.create(
+                        report=new_report,
+                        action_by=uploaded_by,
+                        action_type='MODIFIED_BY_REIMPORT',
+                        comment=f"Correction of terminal record {existing.report_id} — requires OPS review.",
+                    )
+                    _create_items(new_report, dto)
+                updated += 1
+        else:
+            with transaction.atomic():
+                new_report = _create_report(staff, department, dto, batch_id, is_anomaly)
                 AuditLog.objects.create(
                     report=new_report,
                     action_by=uploaded_by,
-                    action_type='MODIFIED_BY_REIMPORT',
-                    comment=f"Correction of terminal record {existing.report_id} — requires OPS review.",
+                    action_type='IMPORTED',
+                    comment=None,
                 )
                 _create_items(new_report, dto)
-                updated += 1
-        else:
-            new_report = _create_report(staff, department, dto, batch_id, is_anomaly)
-            AuditLog.objects.create(
-                report=new_report,
-                action_by=uploaded_by,
-                action_type='IMPORTED',
-                comment=None,
-            )
-            _create_items(new_report, dto)
             created += 1
 
     return {
@@ -286,7 +290,7 @@ def _create_items(report: WorkloadReport, dto: WorkloadRowDTO):
         ))
     if dto.assigned_roles_total_pts > 0:
         # Assigned roles are stored as points × 17.25 to convert back to hours
-        role_hrs = float(dto.assigned_roles_total_pts) * float(WL_HOURS_PER_POINT)
+        role_hrs = Decimal(str(dto.assigned_roles_total_pts)) * WL_HOURS_PER_POINT
         items.append(WorkloadItem(
             report=report,
             category='ASSIGNED_ROLE',

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -642,3 +642,64 @@ class TestExcelImport(BaseTestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.data['code'], 'VALIDATION_ERROR')
         self.assertIn('Missing required header fields', res.data['message'])
+
+    def test_import_skips_unknown_staff_and_reports_error(self):
+        client = self._auth_client(self.ops)
+        excel = self._make_excel_bytes(staff_number='UNKNOWN999')
+        excel.name = 'workload_import.xlsx'
+
+        res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data['created'], 0)
+        self.assertEqual(res.data['skipped'], 1)
+        self.assertTrue(len(res.data['errors']) > 0)
+        self.assertIn('UNKNOWN999', res.data['errors'][0])
+
+    def test_import_skips_casual_staff(self):
+        client = self._auth_client(self.ops)
+        excel = self._make_excel_bytes(staff_type='Paid casual staff')
+        excel.name = 'workload_import.xlsx'
+
+        res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data['created'], 0)
+        self.assertEqual(res.data['skipped'], 1)
+
+    def test_reimport_supersedes_pending_report(self):
+        from api.models import WorkloadReport, AuditLog
+
+        client = self._auth_client(self.ops)
+        # First import — creates a PENDING report
+        excel = self._make_excel_bytes(semester='S1', academic_year=2025)
+        excel.name = 'workload_import.xlsx'
+        res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data['created'], 1)
+
+        # Second import of same staff/semester/year — should supersede
+        excel2 = self._make_excel_bytes(semester='S1', academic_year=2025)
+        excel2.name = 'workload_import.xlsx'
+        res2 = client.post('/api/ops/import/', {'file': excel2}, format='multipart')
+        self.assertEqual(res2.status_code, 201)
+        self.assertEqual(res2.data['updated'], 1)
+
+        # Old report must be marked non-current
+        old = WorkloadReport.objects.filter(
+            staff=self.academic, semester='S1', academic_year=2025, is_current=False
+        )
+        self.assertTrue(old.exists())
+        # New report must be current
+        new = WorkloadReport.objects.get(
+            staff=self.academic, semester='S1', academic_year=2025, is_current=True
+        )
+        self.assertTrue(
+            AuditLog.objects.filter(report=new, action_type='MODIFIED_BY_REIMPORT').exists()
+        )
+
+    def test_import_rejects_non_xlsx_file(self):
+        client = self._auth_client(self.ops)
+        fake_csv = io.BytesIO(b'col1,col2\nval1,val2')
+        fake_csv.name = 'workload.csv'
+
+        res = client.post('/api/ops/import/', {'file': fake_csv}, format='multipart')
+        self.assertIn(res.status_code, [400, 422])

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,6 +1,9 @@
+import io
+
 from django.contrib.auth.models import User
 from rest_framework.test import APITestCase, APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
+import openpyxl
 from .models import Department, Staff, WorkloadReport
 
 
@@ -557,3 +560,85 @@ class TestHOSApproval(BaseTestCase):
             format='json',
         )
         self.assertEqual(res.status_code, 409)
+
+
+# ─── Test: Excel import (#6) ─────────────────────────────────────────────────
+
+class TestExcelImport(BaseTestCase):
+    """Verifies POST /api/ops/import/ for SCHOOL_OPS-only Excel imports."""
+
+    def _make_excel_bytes(self, *, semester='S1', academic_year=2025, department='CSSE',
+                          staff_number=None, staff_type='Academic staff'):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+
+        # File-level context expected by import service
+        ws.cell(row=1, column=2, value=semester)        # B1
+        ws.cell(row=1, column=3, value=academic_year)   # C1
+        ws.cell(row=1, column=4, value=department)      # D1
+
+        headers = [
+            'Staff Member ID', 'Staff Name', 'Staff Number', 'FTE', 'Function',
+            'Target Band', 'Target Teaching %', 'Unit Code', 'Unit Enrolment', 'Staff Type',
+            'Teaching Hrs', 'Teaching WL Pts', 'Unit Coord Hrs', 'Unit Coord WL Pts',
+            'Teaching Activity Hrs', 'Teaching Activity WL Pts', 'Unit Supervision Hrs',
+            'Unit Supervision WL Pts', 'New Unit Dev Hrs', 'New Unit Dev WL Pts',
+            'Total Teaching WL Pts', 'FT Students', 'FT Proportion', 'PT Students',
+            'PT Proportion', 'HDR Total Hrs', 'HDR WL Pts', 'Self-Directed Svc Pts',
+            'Assigned Roles Total Pts', 'Role 1 Name', 'Role 1 Points', 'Role 2 Name',
+            'Role 2 Points', 'Role 3 Name'
+        ]
+        for idx, h in enumerate(headers, 1):
+            ws.cell(row=4, column=idx, value=h)
+
+        row_staff_number = staff_number or self.academic.staff_number
+        row = [
+            f'Test User, {row_staff_number}', 'Test, User', row_staff_number,
+            1.0, 'T & R', 'Balanced Teaching & Research', 50,
+            'CITS5206', 100, staff_type,
+            172.5, 10, 0, 0, 0, 0, 0, 0, 0, 0,
+            10, 2, 0.8, 0, 0, 86.25, 5, 10, 4,
+            'Role A', 2.0, '', 0, ''
+        ]
+        for idx, v in enumerate(row, 1):
+            ws.cell(row=5, column=idx, value=v)
+
+        buffer = io.BytesIO()
+        wb.save(buffer)
+        buffer.seek(0)
+        return buffer
+
+    def test_ops_can_import_excel(self):
+        from api.models import AuditLog, WorkloadItem
+
+        client = self._auth_client(self.ops)
+        excel = self._make_excel_bytes(semester='S2')
+        excel.name = 'workload_import.xlsx'
+
+        res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data['created'], 1)
+        self.assertEqual(res.data['updated'], 0)
+
+        report = WorkloadReport.objects.filter(staff=self.academic, semester='S2', academic_year=2025).latest('created_at')
+        self.assertEqual(report.snapshot_department.name, 'CSSE')
+        self.assertTrue(WorkloadItem.objects.filter(report=report).exists())
+        self.assertTrue(AuditLog.objects.filter(report=report, action_type='IMPORTED').exists())
+
+    def test_non_ops_cannot_import_excel(self):
+        for staff in [self.academic, self.hod_csse, self.hos]:
+            client = self._auth_client(staff)
+            excel = self._make_excel_bytes()
+            excel.name = 'workload_import.xlsx'
+            res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+            self.assertEqual(res.status_code, 403)
+
+    def test_import_fails_when_header_fields_missing(self):
+        client = self._auth_client(self.ops)
+        excel = self._make_excel_bytes(semester='', academic_year='', department='')
+        excel.name = 'workload_import.xlsx'
+
+        res = client.post('/api/ops/import/', {'file': excel}, format='multipart')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.data['code'], 'VALIDATION_ERROR')
+        self.assertIn('Missing required header fields', res.data['message'])

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -21,6 +21,7 @@ from api.view.hos_views import (
     hos_approve,
     hos_reject,
 )
+from api.view.ops_views import import_excel
 
 urlpatterns = [
     # Auth
@@ -46,4 +47,7 @@ urlpatterns = [
     path('workloads/hod-summary/', get_hod_summary),
     path('workloads/<str:id>/hos-approve/', hos_approve),
     path('workloads/<str:id>/hos-reject/', hos_reject),
+
+    # SCHOOL_OPS Excel import (#6)
+    path('ops/import/', import_excel),
 ]

--- a/backend/api/view/ops_views.py
+++ b/backend/api/view/ops_views.py
@@ -1,0 +1,39 @@
+from rest_framework.decorators import api_view, permission_classes, parser_classes
+from rest_framework.parsers import MultiPartParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from api.decorators import require_role
+from api.importers.service import import_workload_excel
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+@parser_classes([MultiPartParser])
+@require_role('SCHOOL_OPS')
+def import_excel(request):
+    """
+    POST /api/ops/import/
+    Upload the Workload Import Template Excel file.
+    The file must have Semester in B1, Academic Year in C1, Department in D1.
+    Returns: { batch_id, created, updated, skipped, errors }
+    """
+    file_obj = request.FILES.get('file')
+    if not file_obj:
+        return Response(
+            {"code": "VALIDATION_ERROR", "message": "No file uploaded. Use field name 'file'."},
+            status=400,
+        )
+
+    if not file_obj.name.endswith(('.xlsx', '.xlsm')):
+        return Response(
+            {"code": "VALIDATION_ERROR", "message": "Only .xlsx or .xlsm files are accepted."},
+            status=400,
+        )
+
+    try:
+        result = import_workload_excel(file_obj, uploaded_by=request.staff)
+    except ValueError as e:
+        return Response({"code": "VALIDATION_ERROR", "message": str(e)}, status=400)
+
+    return Response(result, status=201)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ sqlparse==0.5.5
 
 djangorestframework==3.15.1
 djangorestframework-simplejwt==5.4.0
+openpyxl==3.1.5


### PR DESCRIPTION
## Summary

Implements `POST /api/ops/import/` for SCHOOL_OPS to upload the Workload Import Template Excel file. System parses each row, creates WorkloadReports + WorkloadItems, detects T:R anomalies, and supports reimport version chain.

## What this PR adds

- `backend/api/importers/dto.py` — `WorkloadRowDTO` dataclass decoupling parse layer from persistence
- `backend/api/importers/service.py` — `parse_excel()` + `import_workload_excel()` + `_detect_anomaly()`
- `backend/api/view/ops_views.py` — `POST /api/ops/import/` endpoint (SCHOOL_OPS only)
- `backend/requirements.txt` — added `openpyxl==3.1.5`
- 3 new tests (46/46 total pass)

## Key design decisions

- **DTO pattern**: parse layer and persistence layer are fully decoupled; changing Excel template format only requires touching `parse_excel()`
- **Decimal arithmetic**: workload point calculation uses `Decimal(str(hours)) / Decimal('17.25')` to avoid IEEE 754 float precision errors
- **Tolerant import**: per-row errors collected in `errors[]` list, no full rollback — 48 rows succeed even if 2 rows have bad staff_number
- **Reimport version chain**: PENDING records are superseded (`is_current=False`, `superseded_by=new`); terminal-state records get a correction version
- **File header strategy**: Semester in B1, Academic Year in C1, Department in D1

## API contract

`POST /api/ops/import/` — multipart/form-data, field name `file`, SCHOOL_OPS only

Response 201:
```json
{
  "batch_id": "uuid",
  "created": 45,
  "updated": 3,
  "skipped": 2,
  "errors": ["Staff 99999999 not found — row skipped."]
}
```

Frontend alignment: see Issue #21 `[FE] feature/jaffrey-excel-import API contract`

## Base branch

Rebased onto `feature/jaffrey-hos-approval` to access the 6-table model.
**Merge order: `feature/jaffrey-hos-approval` first, then this PR.**

## Tests

```
Ran 46 tests — OK (0 failures)
```