### PR TITLE
feat(auth): Jaffrey-Gmail SMTP config for OTP email delivery

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -180,3 +180,17 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(hours=8),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
 }
+
+# Email — OTP delivery via SMTP.
+# In development, set EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+# to print codes to the terminal instead of sending real emails.
+EMAIL_BACKEND = os.environ.get(
+    'EMAIL_BACKEND',
+    'django.core.mail.backends.console.EmailBackend',  # dev fallback: prints to terminal
+)
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', '587'))
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'true').lower() == 'true'
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -182,13 +182,16 @@ SIMPLE_JWT = {
 }
 
 # Email — OTP delivery via SMTP.
-# In development, set EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
-# to print codes to the terminal instead of sending real emails.
+# Set EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend in production.
+# Defaults to console backend so dev environments never send real emails accidentally.
 EMAIL_BACKEND = os.environ.get(
     'EMAIL_BACKEND',
-    'django.core.mail.backends.console.EmailBackend',  # dev fallback: prints to terminal
+    'django.core.mail.backends.console.EmailBackend',
 )
-EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com')
+# No hardcoded SMTP defaults — must be set explicitly via environment variables.
+# Gmail example:  EMAIL_HOST=smtp.gmail.com  EMAIL_PORT=587
+# Outlook example: EMAIL_HOST=smtp.office365.com  EMAIL_PORT=587
+EMAIL_HOST = os.environ.get('EMAIL_HOST', '')
 EMAIL_PORT = int(os.environ.get('EMAIL_PORT', '587'))
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'true').lower() == 'true'
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # Email — OTP delivery via Gmail SMTP. Credentials loaded from .env (never commit .env).
       EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
       EMAIL_HOST: smtp.gmail.com
-      EMAIL_PORT: 587
+      EMAIL_PORT: "587"
       EMAIL_USE_TLS: "true"
       EMAIL_HOST_USER: ${EMAIL_HOST_USER}
       EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,14 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
-      # Email — OTP delivery. Set these in .env or override here for local dev.
-      # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
-      # EMAIL_HOST: smtp.gmail.com
-      # EMAIL_PORT: 587
-      # EMAIL_USE_TLS: "true"
-      # EMAIL_HOST_USER: your-gmail@gmail.com
-      # EMAIL_HOST_PASSWORD: your-app-password
-      # DEFAULT_FROM_EMAIL: your-gmail@gmail.com
+      # Email — OTP delivery via Gmail SMTP. Credentials loaded from .env (never commit .env).
+      EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+      EMAIL_HOST: smtp.gmail.com
+      EMAIL_PORT: 587
+      EMAIL_USE_TLS: "true"
+      EMAIL_HOST_USER: ${EMAIL_HOST_USER}
+      EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
+      DEFAULT_FROM_EMAIL: ${EMAIL_HOST_USER}
     command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     ports:
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,14 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
+      # Email — OTP delivery. Set these in .env or override here for local dev.
+      # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+      # EMAIL_HOST: smtp.gmail.com
+      # EMAIL_PORT: 587
+      # EMAIL_USE_TLS: "true"
+      # EMAIL_HOST_USER: your-gmail@gmail.com
+      # EMAIL_HOST_PASSWORD: your-app-password
+      # DEFAULT_FROM_EMAIL: your-gmail@gmail.com
     command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary

Wire up Gmail SMTP so OTP verification codes can actually be sent to users' inboxes.

Previously `send_mail()` had no SMTP config — codes only printed to the Docker terminal log.

## Changes

- `backend/config/settings.py` — added `EMAIL_*` settings block, all read from environment variables. Falls back to `console.EmailBackend` in dev (no real emails sent unless vars are set).
- `docker-compose.yml` — added commented-out placeholder env vars so any dev knows exactly which vars to fill in.

## How to enable real email sending locally

1. Generate a Gmail App Password: Google Account → Security → 2-Step Verification → App passwords
2. Uncomment and fill in the vars in `docker-compose.yml`:

```yaml
EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
EMAIL_HOST: smtp.gmail.com
EMAIL_PORT: 587
EMAIL_USE_TLS: "true"
EMAIL_HOST_USER: your-gmail@gmail.com
EMAIL_HOST_PASSWORD: your-16-char-app-password
DEFAULT_FROM_EMAIL: your-gmail@gmail.com
```

3. `docker-compose up --build` and test the OTP login flow.

## What was NOT changed

- No credentials committed — `.env` is in `.gitignore`
- OTP logic itself (`otp_service.py`) is untouched
- Dev default remains `console.EmailBackend` (safe, no accidental real sends)

## Checklist

- [ ] Fill in Gmail App Password in local `docker-compose.yml` (do NOT commit)
- [ ] Test Send Code → receive email → enter code → login succeeds
- [ ] Confirm `@uwa.edu.au` inbox receives the email without going to spam