### PR TITLE
Feature/hos hod frontend update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ postman/
 
 # Personal notes (not for version control)
 *.md
+!docs/
+!docs/*.md
 *.pdf
 *.xlsx
 *.xlsm

--- a/docs/hod-hos-frontend-api.zh-en.md
+++ b/docs/hod-hos-frontend-api.zh-en.md
@@ -1,0 +1,832 @@
+# HoD / HoS Frontend Interface Alignment (ZH / EN)
+
+## 1. Scope / 范围
+
+**中文**
+
+本文档用于帮助后端同学对齐当前前端原型中与 `HoD` 和 `HoS` 相关的页面行为、字段结构、筛选条件、审批动作、报表导出和权限分配逻辑。  
+文档分为两层：
+
+- `Current frontend prototype`：当前前端页面已经实现的 mock 行为
+- `Backend alignment target`：后端正式接入时应遵循的接口契约和业务规则
+
+**English**
+
+This document helps backend developers align with the current frontend prototype for the `HoD` and `HoS` pages, including page behavior, data fields, filters, approval actions, report export, and permission assignment.  
+The document separates two layers:
+
+- `Current frontend prototype`: the mock behavior already implemented in the frontend
+- `Backend alignment target`: the API contract and business rules the backend should implement
+
+---
+
+## 2. Page Map / 页面映射
+
+| Route | Page | Current frontend component | Notes |
+| --- | --- | --- | --- |
+| `/department-head` | HoD Dashboard | `frontend/src/pages/Supervisor.tsx` | HoD workload approval page |
+| `/school-head` | HoS Dashboard | `frontend/src/pages/HeadofSchool.tsx` | HoS approval + permission assignment |
+| `/academic` | Academic self-submission page | `frontend/src/pages/Academic.tsx` | Currently used for academic submission |
+| `/role` | Role selection | `frontend/src/pages/Role.tsx` | Current HoD card still points to `/supervisor`; route naming should be corrected |
+
+**中文补充**
+
+- 当前路由里 HoD 正式页面是 `/department-head`
+- `Role.tsx` 里 HoD 卡片仍然写的是 `/supervisor`，这是一个前端命名/跳转待修正点
+
+**English note**
+
+- The real HoD route in the router is `/department-head`
+- The HoD card inside `Role.tsx` still points to `/supervisor`; this is a frontend naming / routing issue to be corrected
+
+---
+
+## 3. Key Business Differences / 关键业务差异
+
+### 3.1 Academic submission vs HoD self-submission / Academic 提交与 HoD 自提交流程
+
+**中文**
+
+1. `Academic` 在 `/academic` 提交 `submit request` 后，只进入 `HoD` 页面 `/department-head` 的审批列表，不影响 `HoS`
+2. `HoD` 也需要提交自己的工时，但这个流程虽然目前复用 `/academic` 页面的交互风格，业务上不能再叫 `Academic`
+3. `HoD` 自己提交的工时，目标审批人应该是 `HoS`，即最终应出现在 `/school-head`
+
+**English**
+
+1. When an `Academic` submits a request from `/academic`, it should appear only in the `HoD` queue on `/department-head`, not in `HoS`
+2. `HoD` also needs to submit personal workload, but although the current UI may reuse the `/academic` page pattern, this flow should not be named `Academic`
+3. A `HoD` self-submission should be reviewed by `HoS`, so it should eventually appear in `/school-head`
+
+### 3.2 Mailbox report scope / 邮箱报表范围差异
+
+**中文**
+
+1. `HoD` 邮箱应只看到自己学院 / department 的报表
+2. `HoS` 邮箱逻辑应和 `Ops` (`/school-operations`) 一致，因为 `HoS` 和 `Ops` 都能看所有学院情况
+
+**English**
+
+1. The `HoD` mailbox should show reports only for the HoD's own department
+2. The `HoS` mailbox should follow the same logic as `Ops` (`/school-operations`) because both `HoS` and `Ops` can view all departments
+
+### 3.3 Current mock caveat / 当前 mock 注意事项
+
+**中文**
+
+当前 `Supervisor.tsx` 里的 HoD 邮箱 mock 使用的是 `Annual Department Reports` 命名和 demo 数据；  
+但根据你的最新业务说明，后端正式实现时应以“`自己学院的学期报告`”作为目标规则。
+
+**English**
+
+The current HoD mailbox mock in `Supervisor.tsx` uses `Annual Department Reports` wording and demo data.  
+However, based on the latest product clarification, the backend should treat `department-scoped semester reports` as the target behavior.
+
+---
+
+## 4. Shared Frontend Data Shape / 共享前端数据结构
+
+### 4.1 Approval item / 审批项
+
+Current frontend list/detail pages for HoD and HoS are driven by a shared request-like structure.
+
+```json
+{
+  "id": 101,
+  "sourceWorkloadId": 88,
+  "studentId": "12345931",
+  "semesterLabel": "Sem1",
+  "periodLabel": "2025-1",
+  "name": "Dias John",
+  "unit": "CITS2200",
+  "notes": "Original ops note",
+  "description": "Original description",
+  "requestReason": "wrong",
+  "title": "Lecturer",
+  "department": "Physics",
+  "rate": 70,
+  "status": "pending",
+  "hours": 793.5,
+  "supervisorNote": "",
+  "cancelled": false,
+  "detailSnapshot": {
+    "breakdown": {
+      "Teaching": [{ "name": "CITS2200", "hours": 173 }],
+      "Assigned Roles": [{ "name": "Program Chair", "hours": 20 }],
+      "HDR": [{ "name": "Student A", "hours": 2 }],
+      "Service": [{ "name": "Committee support", "hours": 10 }],
+      "Research (residual)": [{ "name": "Research (residual)", "hours": 0 }]
+    }
+  }
+}
+```
+
+### 4.2 Breakdown category / 工作量拆分 tab
+
+Both HoD and HoS detail modals currently use these tabs:
+
+- `Teaching`
+- `Assigned Roles`
+- `HDR`
+- `Service`
+- `Research (residual)`
+
+### 4.3 Decision note / 审批备注
+
+Approval / rejection currently supports a free-text note to send back to the requester.
+
+```json
+{
+  "decision": "approve",
+  "note": "Please update the justification and resubmit."
+}
+```
+
+---
+
+## 5. HoD Frontend Interface / HoD 前端接口
+
+### 5.1 Page summary / 页面概览
+
+**Route**: `/department-head`  
+**Frontend component**: `frontend/src/pages/Supervisor.tsx`
+
+**Visible tabs / 可见标签**
+
+- `Workload Approval`
+- `Visualization`
+- `Export Excel`
+
+### 5.2 Search and list / 搜索与列表
+
+**Current UI fields / 当前页面筛选项**
+
+- `Name`
+- `Staff ID`
+- `Year & Semester`
+- `Status Filter`
+
+**Current list columns / 当前列表列**
+
+- `Task`
+- `Name`
+- `Title`
+- `Reasons`
+- `Department`
+- `Status`
+- `Total Work Hours`
+- `Submitted Time`
+
+**Backend alignment target / 建议后端列表接口**
+
+`GET /api/hod/workload-requests`
+
+Query params:
+
+| Param | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Fuzzy search by display name |
+| `staffId` | string | Exact or partial staff ID |
+| `year` | number | Reporting year |
+| `semester` | `S1 \| S2` | Semester filter |
+| `status` | `pending \| approved \| rejected \| all` | Status filter |
+| `page` | number | Pagination |
+| `pageSize` | number | Pagination size |
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": 101,
+      "sourceWorkloadId": 88,
+      "staffId": "12345931",
+      "name": "Dias John",
+      "title": "Lecturer",
+      "department": "Physics",
+      "reason": "wrong",
+      "status": "pending",
+      "totalWorkHours": 793.5,
+      "submittedAt": "2026-03-17T16:00:00+08:00"
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "total": 1
+}
+```
+
+### 5.3 Detail modal / 详情弹窗
+
+**Current detail fields / 当前详情字段**
+
+- `Name`
+- `Staff ID`
+- `Target teaching ratio`
+- `Actual teaching ratio`
+- `Total work hours`
+- `Employment type`
+- `New Staff`
+- `HoD Review`
+- `Workload Breakdown`
+- `School of Operations notes`
+- `Application Reason`
+
+**Backend alignment target / 建议后端详情接口**
+
+`GET /api/hod/workload-requests/{requestId}`
+
+Example response:
+
+```json
+{
+  "id": 101,
+  "staffId": "12345931",
+  "name": "Dias John",
+  "title": "Lecturer",
+  "department": "Physics",
+  "periodLabel": "2025-1",
+  "targetTeachingRatio": 50.0,
+  "actualTeachingRatio": 16.8,
+  "totalWorkHours": 1030.5,
+  "employmentType": "Full-time",
+  "isNewStaff": false,
+  "hodReviewRequired": false,
+  "schoolOperationsNotes": "Original note from Ops",
+  "applicationReason": "wrong",
+  "status": "pending",
+  "breakdown": {
+    "Teaching": [{ "name": "CITS2002", "hours": 173 }],
+    "Assigned Roles": [],
+    "HDR": [],
+    "Service": [],
+    "Research (residual)": []
+  },
+  "canEditBreakdown": true,
+  "cancelled": false
+}
+```
+
+### 5.4 Approve / reject / 审批动作
+
+**Current frontend behavior / 当前前端行为**
+
+- pending item shows `Approve` and `Decline`
+- note modal appears before final decision
+- status and note are written back to the requester-side mock state
+
+**Backend alignment target / 建议后端审批接口**
+
+`POST /api/hod/workload-requests/{requestId}/decision`
+
+Request:
+
+```json
+{
+  "decision": "approve",
+  "note": "Approved after checking the workload breakdown."
+}
+```
+
+Response:
+
+```json
+{
+  "id": 101,
+  "status": "approved",
+  "reviewedBy": {
+    "staffId": "12345931",
+    "name": "Rachel"
+  },
+  "reviewedAt": "2026-05-08T12:30:00+08:00",
+  "note": "Approved after checking the workload breakdown."
+}
+```
+
+### 5.5 HoD mailbox report / HoD 邮箱报表
+
+**Required business rule / 业务规则**
+
+- HoD sees reports only for the HoD's own department
+- Based on your latest clarification, the target behavior should be `department-scoped semester reports`
+- The current prototype already supports inbox display + Excel download, but the naming/data seed is still a local mock
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hod/reports/semester`
+
+Query params:
+
+- `year`
+- `semester`
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": "hod-report-2025-S1-physics",
+      "year": 2025,
+      "semester": "S1",
+      "department": "Physics",
+      "title": "2025 S1 Physics report generated",
+      "createdAt": "2025-07-01T09:00:00+08:00",
+      "downloadUrl": "/api/hod/reports/semester/hod-report-2025-S1-physics/download",
+      "unread": true
+    }
+  ]
+}
+```
+
+Download:
+
+`GET /api/hod/reports/semester/{reportId}/download`
+
+**Excel expectation / Excel 期望**
+
+- one row per department workload request item
+- include at least:
+  - `Staff ID`
+  - `Name`
+  - `Department`
+  - `Title`
+  - `Semester`
+  - `Status`
+  - `Total Work Hours`
+  - `Submitted Time`
+  - `Application Reason`
+  - `HoD Review Note`
+
+### 5.6 Visualization / 可视化
+
+**Current UI filters / 当前筛选**
+
+- `fromYear`
+- `toYear`
+- `semester`
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hod/analytics/workloads`
+
+Query params:
+
+- `fromYear`
+- `toYear`
+- `semester=All|S1|S2`
+
+Suggested response sections:
+
+- summary cards
+- yearly / semester trend
+- approved / rejected / pending counts
+- workload hours distribution
+
+### 5.7 Export Excel / 导出 Excel
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hod/exports/workloads`
+
+Query params:
+
+- `fromYear`
+- `toYear`
+- `semester`
+
+Response:
+
+- binary `.xlsx`
+
+### 5.8 Upstream submission to HoD / 流入 HoD 的提交流程
+
+**Current frontend prototype / 当前原型**
+
+`Academic.tsx` currently writes submit requests into HoD-facing mock storage.
+
+**Backend alignment target / 建议后端接口**
+
+`POST /api/academic/workload-requests`
+
+Request:
+
+```json
+{
+  "sourceWorkloadId": 88,
+  "staffId": "12345931",
+  "periodLabel": "2025-1",
+  "applicationReason": "wrong",
+  "title": "Lecturer",
+  "department": "Physics",
+  "totalWorkHours": 793.5,
+  "targetTeachingRatio": 50.0,
+  "teachingTargetHours": 400,
+  "detailSnapshot": {
+    "breakdown": {
+      "Teaching": [{ "name": "CITS2200", "hours": 173 }]
+    }
+  }
+}
+```
+
+Important rule:
+
+- Normal academic submission goes to `HoD`
+- It should not appear in the `HoS` page directly
+
+### 5.9 HoD self-submission to HoS / HoD 自提交流向 HoS
+
+**Business clarification / 业务说明**
+
+- HoD also submits personal workload
+- This should reuse a similar self-service UI pattern, but should not continue to be named `Academic`
+- The target reviewer for HoD self-submission is `HoS`
+
+**Backend alignment target / 建议后端接口**
+
+`POST /api/hod/self-workload-requests`
+
+Request shape can be the same as academic submission, but actor / target role is different.
+
+---
+
+## 6. HoS Frontend Interface / HoS 前端接口
+
+### 6.1 Page summary / 页面概览
+
+**Route**: `/school-head`  
+**Frontend component**: `frontend/src/pages/HeadofSchool.tsx`
+
+**Visible tabs / 可见标签**
+
+- `HoS Workload Approval`
+- `Permission Assignment`
+- `Visualization`
+- `Export Excel`
+
+### 6.2 Search and list / 搜索与列表
+
+**Current UI fields / 当前筛选项**
+
+- `Name`
+- `Staff ID`
+- `Department`
+- `Year & Semester`
+- `Status Filter`
+
+**Current list columns / 当前列表列**
+
+- `Task`
+- `Name`
+- `Title`
+- `Reasons`
+- `Department`
+- `Status`
+- `Total Work Hours`
+- `Submitted Time`
+
+**Backend alignment target / 建议后端列表接口**
+
+`GET /api/hos/workload-requests`
+
+Query params:
+
+| Param | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Name fuzzy search |
+| `staffId` | string | Staff ID search |
+| `department` | string | Department filter |
+| `year` | number | Reporting year |
+| `semester` | `S1 \| S2` | Semester filter |
+| `status` | `pending \| approved \| rejected \| all` | Status filter |
+| `page` | number | Pagination |
+| `pageSize` | number | Pagination size |
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": 201,
+      "staffId": "12345931",
+      "name": "Dias John",
+      "title": "Lecturer",
+      "department": "Physics",
+      "reason": "wrong",
+      "status": "pending",
+      "totalWorkHours": 793.5,
+      "submittedAt": "2026-03-17T16:00:00+08:00"
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "total": 1
+}
+```
+
+### 6.3 Detail modal / 详情弹窗
+
+The current HoS detail modal has been aligned to the HoD detail structure, but it remains an independent page implementation.
+
+**Current detail fields / 当前详情字段**
+
+- `Name`
+- `Staff ID`
+- `Target teaching ratio`
+- `Actual teaching ratio`
+- `Total work hours`
+- `Employment type`
+- `New Staff`
+- `HoD Review`
+- `Workload Breakdown`
+- `School of Operations notes`
+- `Application Reason`
+
+**Backend alignment target / 建议后端详情接口**
+
+`GET /api/hos/workload-requests/{requestId}`
+
+Response shape can match the HoD detail contract.
+
+### 6.4 Approve / reject / 审批动作
+
+**Backend alignment target / 建议后端接口**
+
+`POST /api/hos/workload-requests/{requestId}/decision`
+
+Request:
+
+```json
+{
+  "decision": "reject",
+  "note": "Please revise the workload breakdown before final approval."
+}
+```
+
+### 6.5 HoS mailbox report / HoS 邮箱报表
+
+**Required business rule / 业务规则**
+
+- HoS mailbox should behave like `Ops`
+- HoS can see all departments
+- The report type is semester-level distribution reporting with Excel download
+
+**Current frontend prototype / 当前原型**
+
+- the page already uses a `Semester Distribution Reports` modal
+- demo data is seeded on the frontend
+- download is already handled entirely in the frontend mock
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hos/reports/semester-distribution`
+
+Query params:
+
+- `year`
+- `semester`
+- optional `department`
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": "hos-report-2025-S1",
+      "year": 2025,
+      "semester": "S1",
+      "title": "2025 S1 distribution report generated",
+      "createdAt": "2025-07-01T09:00:00+08:00",
+      "downloadUrl": "/api/hos/reports/semester-distribution/hos-report-2025-S1/download",
+      "unread": true
+    }
+  ]
+}
+```
+
+Download:
+
+`GET /api/hos/reports/semester-distribution/{reportId}/download`
+
+### 6.6 Permission Assignment / 权限分配
+
+**Current UI sections / 当前页面功能**
+
+- search staff
+- import template
+- assign role
+- assign department
+- persist and view assigned role list
+- disable assignment
+
+**Current role domain / 当前角色范围**
+
+- `HoD`
+- `Admin`
+
+**Current department domain / 当前部门范围**
+
+- `Physics`
+- `Mathematics & Statistics`
+- `Computer Science & Software Engineering`
+- `Senior School Coordinator`
+
+**Suggested staff list API / 建议人员搜索接口**
+
+`GET /api/hos/staff-directory`
+
+Query params:
+
+- `firstName`
+- `lastName`
+- `staffId`
+- `isActive`
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": 1,
+      "staffId": "12345931",
+      "firstName": "Dias",
+      "lastName": "John",
+      "email": "dias.john@uwa.edu.au",
+      "title": "Lecturer",
+      "currentDepartment": "Physics",
+      "isActive": true,
+      "isNewEmployee": false,
+      "notes": ""
+    }
+  ]
+}
+```
+
+**Suggested import API / 建议模板导入接口**
+
+`POST /api/hos/staff-directory/import`
+
+- multipart upload
+- backend validates template and returns parsed rows + validation messages
+
+**Suggested assignment create API / 建议分配接口**
+
+`POST /api/hos/role-assignments`
+
+Request:
+
+```json
+{
+  "staffId": "12345931",
+  "role": "HoD",
+  "department": "Physics"
+}
+```
+
+Response:
+
+```json
+{
+  "id": 5001,
+  "staffId": "12345931",
+  "name": "Dias John",
+  "role": "HoD",
+  "department": "Physics",
+  "permissions": [
+    "View Workload",
+    "Approve Workload",
+    "Update Workload"
+  ],
+  "assignedAt": "2026-05-08T12:30:00+08:00",
+  "status": "active"
+}
+```
+
+**Suggested assignment list API / 建议已分配列表接口**
+
+`GET /api/hos/role-assignments`
+
+**Suggested disable API / 建议停用接口**
+
+`PATCH /api/hos/role-assignments/{assignmentId}/status`
+
+Request:
+
+```json
+{
+  "status": "disabled"
+}
+```
+
+### 6.7 Visualization / 可视化
+
+**Current UI filters / 当前筛选**
+
+- `fromYear`
+- `toYear`
+- `semester`
+- `department`
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hos/analytics/workloads`
+
+Query params:
+
+- `fromYear`
+- `toYear`
+- `semester=All|S1|S2`
+- `department=All Departments|Physics|...`
+
+Suggested response sections:
+
+- school summary
+- department comparison
+- yearly and semester trends
+- workload and approval distribution
+
+### 6.8 Export Excel / 导出 Excel
+
+**Backend alignment target / 建议后端接口**
+
+`GET /api/hos/exports/workloads`
+
+Query params:
+
+- `fromYear`
+- `toYear`
+- `semester`
+- `department`
+
+Response:
+
+- binary `.xlsx`
+
+---
+
+## 7. Current Frontend Mock Storage / 当前前端 mock 存储
+
+These are not final backend APIs, but they explain how the frontend is currently wired before backend integration.
+
+| Key | Used by | Meaning |
+| --- | --- | --- |
+| `academic_to_supervisor_requests_v1` | Academic / HoD / HoS | pending submission queue mock |
+| `supervisor_requests_state_v1` | HoD / HoS | locally merged approval state |
+| `academic_status_sync_v1` | Academic / HoD / HoS | request status sync mock |
+| `academic_notes_sync_v1` | Academic / HoD / HoS | reviewer note sync mock |
+| `hod_annual_report_inbox_v1` | HoD | current prototype mailbox cache |
+| `hos_semester_report_inbox_v1` | HoS | HoS mailbox cache |
+| `hod_role_assignments_v1` | HoS | permission assignment cache |
+
+**中文**
+
+后端接入后，这些 `localStorage` key 应逐步退出，只保留必要的前端 UI 缓存。
+
+**English**
+
+Once backend APIs are integrated, these `localStorage` keys should gradually be removed, except for optional UI-only caching if needed.
+
+---
+
+## 8. Recommended Integration Order / 建议联调顺序
+
+**中文**
+
+建议后端联调顺序如下：
+
+1. 先接 `HoD / HoS workload request list + detail + decision`
+2. 再接 `Academic -> HoD` 提交流程
+3. 再区分 `HoD self-submission -> HoS`
+4. 然后接 `HoD / HoS mailbox report download`
+5. 最后接 `HoS permission assignment`, visualization, export
+
+**English**
+
+Recommended backend integration order:
+
+1. First implement `HoD / HoS workload request list + detail + decision`
+2. Then wire `Academic -> HoD` submission
+3. Then separate `HoD self-submission -> HoS`
+4. After that, integrate `HoD / HoS mailbox report download`
+5. Finally implement `HoS permission assignment`, visualization, and export
+
+---
+
+## 9. Known Frontend Notes / 当前前端注意点
+
+**中文**
+
+- `Role.tsx` 中 HoD 卡片路由仍指向 `/supervisor`，与 `App.tsx` 中的 `/department-head` 不一致
+- HoD 邮箱 prototype 当前仍使用 annual wording，但后端应按你最新规则实现成 department-scoped semester reports
+- HoD 和 HoS 的详情布局已经尽量对齐，但它们仍应保持独立页面逻辑和独立权限边界
+
+**English**
+
+- The HoD card in `Role.tsx` still points to `/supervisor`, while the real app route is `/department-head`
+- The HoD mailbox prototype still uses annual wording, but the backend should implement department-scoped semester reports based on the latest requirement
+- HoD and HoS detail layouts are visually aligned, but they should remain independent pages with independent permission boundaries
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Login from "./pages/Login";
 import Role from "./pages/Role";
 import Academic from "./pages/Academic";
@@ -14,11 +14,9 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/role" element={<Role />} />
         <Route path="/academic" element={<Academic />} />
-        <Route path="/supervisor" element={<Supervisor />} />
+        <Route path="/department-head" element={<Supervisor />} />
         <Route path="/school-operations" element={<SchoolofOperations />} />
-        <Route path="/schoolofoperations" element={<Navigate to="/school-operations" replace />} />
-        <Route path="/admin" element={<Navigate to="/school-operations" replace />} />
-        <Route path="/headofschool" element={<HeadofSchool />} />
+        <Route path="/school-head" element={<HeadofSchool />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Academic.tsx
+++ b/frontend/src/pages/Academic.tsx
@@ -136,6 +136,7 @@ function isDetailHoursAbnormal(item: AcademicItem, breakdown: BreakdownData): bo
 
 type SupervisorDraftRequest = {
   id: number;
+  sourceWorkloadId?: number;
   studentId: string;
   semesterLabel: string;
   periodLabel: string;
@@ -152,10 +153,10 @@ type SupervisorDraftRequest = {
   hours: number;
   targetTeachingRatio?: number;
   teachingTargetHours?: number;
+  detailSnapshot?: WorkloadDetailSnapshot;
 };
 
 const SUPERVISOR_DRAFT_KEY = "academic_to_supervisor_requests_v1";
-const SUPERVISOR_STATE_KEY = "supervisor_requests_state_v1";
 const ACADEMIC_STATUS_SYNC_KEY = "academic_status_sync_v1";
 const ACADEMIC_NOTES_SYNC_KEY = "academic_notes_sync_v1";
 const SUPERVISOR_SYNC_EVENT = "supervisor-status-updated";
@@ -241,14 +242,11 @@ function applySyncedStatus(
   noteMap: Record<string, string>
 ) {
   return rows.map((item) => {
-    const syncedStatus = synced[item.employeeId];
-    const syncedNote = noteMap[item.employeeId];
+    const syncedStatus = synced[String(item.id)];
+    const syncedNote = noteMap[String(item.id)];
     if (!syncedStatus && !syncedNote) return item;
-    const nextStatus: AcademicItem["status"] =
-      item.status === ""
-        ? // Freshly distributed workload must stay "-" until Academic clicks Submit Request.
-          ""
-        : syncedStatus || item.status;
+    // Keep "-" as initialization when no synced status; otherwise follow HoD sync.
+    const nextStatus: AcademicItem["status"] = syncedStatus || item.status;
     return {
       ...item,
       status: nextStatus,
@@ -260,9 +258,7 @@ function applySyncedStatus(
 function readDistributedItemsForAcademic(employeeId: string): AcademicItem[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw =
-      window.localStorage.getItem(OPS_ACADEMIC_DISTRIBUTED_KEY) ??
-      window.localStorage.getItem(SUPERVISOR_STATE_KEY);
+    const raw = window.localStorage.getItem(OPS_ACADEMIC_DISTRIBUTED_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -272,7 +268,6 @@ function readDistributedItemsForAcademic(employeeId: string): AcademicItem[] {
       const sid = String(row.studentId ?? "").trim();
       return sid === employeeId && row.cancelled !== true && row.status === "approved";
     });
-
     return filtered.map((row, idx) => {
       const sid = String(row.studentId ?? "").trim();
       const rawHodReview = String(row.hodReview ?? "").trim().toLowerCase();
@@ -510,7 +505,19 @@ function AcademicDetailModal({
     item.targetTeachingRatio != null ? `${(Math.round(item.targetTeachingRatio * 10) / 10).toFixed(1)}%` : "—";
   const displayActualTeachingRatio =
     item.detailSnapshot?.actualTeachingRatioDisplay ?? `${actualTeachingRatioPercent(breakdown)}%`;
-  const displayTotalWorkHours = item.detailSnapshot?.totalHoursDisplay ?? String(item.hours);
+  // Keep modal and table on the same source of truth (`item.hours`), while
+  // still showing Ops-provided range hint suffix when it matches.
+  const canonicalHoursText = String(item.hours);
+  const snapshotDisplay = item.detailSnapshot?.totalHoursDisplay?.trim() ?? "";
+  const snapshotMatch = snapshotDisplay.match(/^([0-9]+(?:\.[0-9]+)?)\s*(.*)$/);
+  const snapshotLeadingHours = snapshotMatch?.[1] ?? "";
+  const snapshotSuffix = snapshotMatch?.[2]?.trim() ?? "";
+  const snapshotHoursMismatch =
+    Boolean(snapshotDisplay) && snapshotLeadingHours !== canonicalHoursText;
+  const displayTotalWorkHours =
+    !snapshotHoursMismatch && snapshotSuffix
+      ? `${canonicalHoursText} ${snapshotSuffix}`
+      : canonicalHoursText;
   const actualRatioInputClassName = item.detailSnapshot?.actualTeachingRatioOutOfRange
     ? "border-red-500 ring-1 ring-red-300 bg-red-50/60 text-red-900"
     : item.detailSnapshot?.showActualTeachingRatioBandWarning
@@ -519,7 +526,7 @@ function AcademicDetailModal({
   const actualRatioTooltipClassName = item.detailSnapshot?.actualTeachingRatioOutOfRange
     ? "border-red-300 bg-red-50 text-red-900"
     : "border-yellow-300 bg-yellow-50 text-amber-900";
-  const totalHoursInputClassName = item.detailSnapshot?.adminModalHoursAbnormal
+  const totalHoursInputClassName = !snapshotHoursMismatch && item.detailSnapshot?.adminModalHoursAbnormal
     ? "border-red-500 ring-1 ring-red-300 bg-red-50/40 text-red-900 text-xs sm:text-sm"
     : "text-xs sm:text-sm";
   const tabRows = breakdown[activeTab];
@@ -567,7 +574,7 @@ function AcademicDetailModal({
               value={displayTotalWorkHours}
               className="tabular-nums font-sans"
               inputClassName={totalHoursInputClassName}
-              tooltipText={item.detailSnapshot?.totalHoursTooltipText || ""}
+              tooltipText={!snapshotHoursMismatch ? item.detailSnapshot?.totalHoursTooltipText || "" : ""}
             />
             <InfoField label="Employment type" value={item.detailSnapshot?.employmentType || item.employmentType || "—"} />
             <InfoField label="New Staff" value={item.newStaff || "—"} />
@@ -896,6 +903,13 @@ export default function Academic() {
     () => computeYAxisDomain(trendChartData.map((item) => item.totalHours)),
     [trendChartData]
   );
+
+  useEffect(() => {
+    // Safety cleanup: remove legacy blocked message from earlier client-only logic.
+    if (requestInfo.toLowerCase().startsWith("submit blocked:")) {
+      setRequestInfo("");
+    }
+  }, [requestInfo]);
   const reportingPeriodLabel = useMemo(() => {
     if (!visualizationSemesterSlots.length) return "N/A";
     const firstYear = Number(visualizationSemesterSlots[0].key.split("-")[0]);
@@ -925,7 +939,6 @@ export default function Academic() {
     function onStorage(e: StorageEvent) {
       if (
         e.key === OPS_ACADEMIC_DISTRIBUTED_KEY ||
-        e.key === SUPERVISOR_STATE_KEY ||
         e.key === ACADEMIC_STATUS_SYNC_KEY ||
         e.key === ACADEMIC_NOTES_SYNC_KEY ||
         e.key === OPS_ACADEMIC_NOTIFICATION_KEY
@@ -955,6 +968,7 @@ export default function Academic() {
 
     const drafts: SupervisorDraftRequest[] = rows.map((row, idx) => ({
       id: Date.now() + idx,
+      sourceWorkloadId: row.id,
       studentId: row.employeeId,
       semesterLabel: "Sem1",
       periodLabel: "2025-1",
@@ -969,12 +983,26 @@ export default function Academic() {
       hours: row.hours,
       targetTeachingRatio: row.targetTeachingRatio,
       teachingTargetHours: row.teachingTargetHours,
+      detailSnapshot: row.detailSnapshot,
     }));
 
     if (typeof window !== "undefined") {
       const raw = window.localStorage.getItem(SUPERVISOR_DRAFT_KEY);
       const existing = raw ? (JSON.parse(raw) as SupervisorDraftRequest[]) : [];
       window.localStorage.setItem(SUPERVISOR_DRAFT_KEY, JSON.stringify([...drafts, ...existing]));
+
+      // Persist pending status immediately so Academic table won't fall back to "-"
+      // when other localStorage sync flows refresh rows from distributed snapshots.
+      const statusRaw = window.localStorage.getItem(ACADEMIC_STATUS_SYNC_KEY);
+      const statusMap =
+        statusRaw && typeof statusRaw === "string"
+          ? (JSON.parse(statusRaw) as Record<string, "pending" | "approved" | "rejected">)
+          : {};
+      rows.forEach((row) => {
+        statusMap[String(row.id)] = "pending";
+      });
+      window.localStorage.setItem(ACADEMIC_STATUS_SYNC_KEY, JSON.stringify(statusMap));
+      window.dispatchEvent(new Event(SUPERVISOR_SYNC_EVENT));
       window.dispatchEvent(new Event(ACADEMIC_DRAFT_EVENT));
     }
 
@@ -988,10 +1016,12 @@ export default function Academic() {
   }
 
   function openRequestModal() {
+    setRequestInfo("");
     if (selectedIds.size === 0) {
       setRequestInfo("Please select at least one row before submitting.");
       return;
     }
+
     setRequestReason("");
     setRequestReasonError("");
     setRequestModalOpen(true);
@@ -1328,7 +1358,7 @@ export default function Academic() {
 
           <div className="mt-10 text-4xl font-semibold text-slate-700">Workload Report Sem 1 - 2025</div>
 
-          <div className="mt-6 rounded-md bg-white p-4 ring-1 ring-slate-200">
+          <div className="mt-6 rounded-md bg-[#eef3fb] p-4 ring-1 ring-slate-200">
             <div className="overflow-x-auto">
               <div className="max-h-[520px] overflow-y-auto">
                 <table className="min-w-full border-separate border-spacing-y-0">
@@ -1345,7 +1375,7 @@ export default function Academic() {
                     <th className="px-3 py-2 whitespace-nowrap text-right">Push time</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-200 bg-white">
+                <tbody className="divide-y divide-slate-200 bg-[#eef3fb]">
                   {pageItems.map((item, idx) => {
                     const selected = selectedIds.has(item.id);
                     const rowCancelled = Boolean(item.cancelled);
@@ -1363,7 +1393,7 @@ export default function Academic() {
                         className={`text-sm ${
                           rowCancelled
                             ? "cursor-not-allowed border-y border-slate-300/80 bg-slate-200 text-slate-500"
-                            : `cursor-pointer ${selected ? "border-l-4 border-[#2f4d9c] bg-[#eef2ff]" : ""}`
+                            : `cursor-pointer ${selected ? "border-l-4 border-[#2f4d9c] bg-[#eef2ff]" : "bg-white"}`
                         }`}
                       >
                         <td className="px-2 py-3" onClick={(e) => e.stopPropagation()}>
@@ -1432,6 +1462,13 @@ export default function Academic() {
                       </tr>
                     );
                   })}
+                  {pageItems.length === 0 && (
+                    <tr>
+                      <td colSpan={9} className="px-3 py-6 text-center text-sm text-slate-500">
+                        No items found
+                      </td>
+                    </tr>
+                  )}
                 </tbody>
                 </table>
               </div>

--- a/frontend/src/pages/Academic.tsx
+++ b/frontend/src/pages/Academic.tsx
@@ -540,9 +540,14 @@ function AcademicDetailModal({
       <div className="w-full max-w-2xl rounded-md bg-white shadow-lg" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between rounded-t-md bg-[#2f4d9c] px-5 py-3 text-white">
           <div className="flex items-center gap-3">
-            <div className="text-lg font-bold">Academic Workload Detail</div>
+            <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+              {`${yearSemesterById(item.id).year}-${yearSemesterById(item.id).semester}`}
+            </div>
             <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
               {item.department || "Department N/A"}
+            </div>
+            <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+              Academic
             </div>
           </div>
           <button

--- a/frontend/src/pages/Academic.tsx
+++ b/frontend/src/pages/Academic.tsx
@@ -539,16 +539,8 @@ function AcademicDetailModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
       <div className="w-full max-w-2xl rounded-md bg-white shadow-lg" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between rounded-t-md bg-[#2f4d9c] px-5 py-3 text-white">
-          <div className="flex items-center gap-3">
-            <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-              {`${yearSemesterById(item.id).year}-${yearSemesterById(item.id).semester}`}
-            </div>
-            <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-              {item.department || "Department N/A"}
-            </div>
-            <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-              Academic
-            </div>
+          <div className="text-lg font-bold">
+            {`${yearSemesterById(item.id).year}-${yearSemesterById(item.id).semester}-${item.department || "Department N/A"}-Academic`}
           </div>
           <button
             type="button"

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -3249,7 +3249,7 @@ export default function SchoolofOperations() {
               )}
 
               <div className="mt-4 rounded-md bg-[#f4f7ff] p-4">
-                <div className="grid grid-cols-1 gap-6 md:grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,1.2fr)]">
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
                   <div className="flex flex-col gap-1">
                     <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Name</div>
                     <input
@@ -3286,7 +3286,7 @@ export default function SchoolofOperations() {
                     </select>
                   </div>
                 </div>
-                <div className="mt-4 grid grid-cols-1 items-end gap-6 md:grid-cols-[1fr_auto_1fr]">
+                <div className="mt-4 grid grid-cols-1 items-end gap-6 md:grid-cols-3">
                   <div className="flex flex-col gap-1">
                     <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Year & Semester</div>
                     <div className="flex w-full min-w-0 items-center gap-2">
@@ -3317,7 +3317,7 @@ export default function SchoolofOperations() {
                       </select>
                     </div>
                   </div>
-                  <div className="flex justify-center md:justify-self-center">
+                  <div className="flex items-end justify-center md:justify-self-center">
                     <SearchButton onClick={handleSearch} />
                   </div>
                   <span className="hidden md:block" aria-hidden />

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -22,7 +22,6 @@ import InfoField from "../components/common/InfoField";
 import PaginationControls from "../components/common/PaginationControls";
 import ProfileModal from "../components/common/ProfileModal";
 import SearchButton from "../components/common/SearchButton";
-import { MOCK_DASHBOARD_USER } from "../data/mockDashboardUser";
 import SectionTabs from "../components/common/SectionTabs";
 import SectionTitleBlock from "../components/common/SectionTitleBlock";
 import StaffProfileModal, {
@@ -144,14 +143,12 @@ const ADMIN_WORKLOAD_BREAKDOWN_TABS: BreakdownCategory[] = [
   "Research (residual)",
 ];
 
-const SUPERVISOR_DRAFT_KEY = "academic_to_supervisor_requests_v1";
-const SUPERVISOR_STATE_KEY = "supervisor_requests_state_v1";
+const OPS_ACADEMIC_NOTIFICATION_KEY = "ops_to_academic_notifications_v1";
+const OPS_ACADEMIC_DISTRIBUTED_KEY = "ops_academic_distributed_workloads_v1";
+const OPS_SEMESTER_REPORTS_KEY = "ops_semester_report_inbox_v1";
 const ACADEMIC_STATUS_SYNC_KEY = "academic_status_sync_v1";
 const ACADEMIC_NOTES_SYNC_KEY = "academic_notes_sync_v1";
 const SUPERVISOR_SYNC_EVENT = "supervisor-status-updated";
-const ACADEMIC_DRAFT_EVENT = "academic-drafts-updated";
-const OPS_ACADEMIC_NOTIFICATION_KEY = "ops_to_academic_notifications_v1";
-const OPS_ACADEMIC_DISTRIBUTED_KEY = "ops_academic_distributed_workloads_v1";
 const SEMESTER_EXPECTED_MIN_HOURS = 856;
 const SEMESTER_EXPECTED_MAX_HOURS = 864;
 const WORKLOAD_REPORT_SEMESTER_LABEL = "2025-S1";
@@ -176,6 +173,47 @@ type AcademicNotification = {
   sentAt: string;
   readAt?: string;
 };
+
+type OpsSemesterReportItem = {
+  id: string;
+  year: number;
+  semester: "S1" | "S2";
+  title: string;
+  createdAt: string;
+  readAt?: string;
+  rows: Record<string, string | number>[];
+};
+
+function readOpsSemesterReports(): OpsSemesterReportItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(OPS_SEMESTER_REPORTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as OpsSemesterReportItem[];
+  } catch {
+    return [];
+  }
+}
+
+function writeOpsSemesterReports(items: OpsSemesterReportItem[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(OPS_SEMESTER_REPORTS_KEY, JSON.stringify(items));
+}
+
+function readAcademicStatusSync(): Record<string, "pending" | "approved" | "rejected"> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(ACADEMIC_STATUS_SYNC_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as Record<string, "pending" | "approved" | "rejected">;
+  } catch {
+    return {};
+  }
+}
 
 function formatOpsDistributionDdl(semester: "S1" | "S2") {
   if (semester === "S1") return "S1 (1 January - 30 June)";
@@ -212,47 +250,6 @@ function modifiedTimeById(id: number) {
   const day = ((id + 1) % 28) + 1;
   const hour = 9 + (id % 8);
   return `2026-03-${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:30`;
-}
-
-function readAcademicDrafts(): MockRequest[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(SUPERVISOR_DRAFT_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed as MockRequest[];
-  } catch {
-    return [];
-  }
-}
-
-function consumeAcademicDrafts(): MockRequest[] {
-  if (typeof window === "undefined") return [];
-  const drafts = readAcademicDrafts();
-  window.localStorage.removeItem(SUPERVISOR_DRAFT_KEY);
-  return drafts;
-}
-
-function readSupervisorState(): MockRequest[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(SUPERVISOR_STATE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed as MockRequest[];
-  } catch {
-    return [];
-  }
-}
-
-function mergeDraftsIntoRequests(current: MockRequest[], drafts: MockRequest[]) {
-  if (!drafts.length) return current;
-  const existingIds = new Set(current.map((row) => row.id));
-  const incoming = drafts.filter((row) => !existingIds.has(row.id));
-  if (!incoming.length) return current;
-  return [...incoming, ...current];
 }
 
 function breakdownById(id: number, totalHours: number): BreakdownData {
@@ -843,10 +840,25 @@ export default function SchoolofOperations() {
     status: "active" | "disabled";
   };
 
-  const user = MOCK_DASHBOARD_USER;
+  const user = {
+    surname: "Bronte",
+    firstName: "Yaka",
+    employeeId: "2345678",
+    title: "Professor",
+    department: "Senior School",
+    email: "yaka.bronte@uwa.edu.au",
+  };
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [avatarSrc, setAvatarSrc] = useState<string | null>(null);
+  const [opsReportInboxOpen, setOpsReportInboxOpen] = useState(false);
+  const [opsReportInboxPage, setOpsReportInboxPage] = useState(1);
+  const [opsSemesterReports, setOpsSemesterReports] = useState<OpsSemesterReportItem[]>(() =>
+    readOpsSemesterReports()
+  );
+  const [academicStatusSyncMap, setAcademicStatusSyncMap] = useState<
+    Record<string, "pending" | "approved" | "rejected">
+  >(() => readAcademicStatusSync());
   const [activeSection, setActiveSection] = useState<
     "approval" | "admin" | "visualization" | "export"
   >("approval");
@@ -862,45 +874,121 @@ export default function SchoolofOperations() {
   const [pending, setPending] = useState<MockRequest[]>([]);
 
   useEffect(() => {
-    function mergeLatestDrafts() {
-      const drafts = consumeAcademicDrafts();
-      if (!drafts.length) return;
-      setPending((prev) => mergeDraftsIntoRequests(prev, drafts));
-    }
+    const now = new Date();
+    const existing = readOpsSemesterReports();
+    const existingKeys = new Set(existing.map((item) => `${item.year}-${item.semester}`));
+    const semesterKeys = new Set<string>();
 
-    function onStorage(e: StorageEvent) {
-      if (e.key === SUPERVISOR_DRAFT_KEY) mergeLatestDrafts();
-    }
+    pending.forEach((row) => {
+      if (row.cancelled) return;
+      const matched = row.periodLabel.match(/^(\d{4})-(1|2)$/);
+      if (!matched) return;
+      const year = Number(matched[1]);
+      const semester = matched[2] === "1" ? "S1" : "S2";
+      if (now <= semesterEndDate(year, semester)) return;
+      semesterKeys.add(`${year}-${semester}`);
+    });
 
-    function onDraftEvent() {
-      mergeLatestDrafts();
-    }
+    const newReports: OpsSemesterReportItem[] = [];
+    semesterKeys.forEach((key) => {
+      if (existingKeys.has(key)) return;
+      const [yearText, semester] = key.split("-") as [string, "S1" | "S2"];
+      const year = Number(yearText);
+      const semesterRows = pending
+        .filter((row) => !row.cancelled && row.periodLabel === `${year}-${semester === "S1" ? "1" : "2"}`)
+        .map((row) => ({
+          "Staff ID": row.studentId,
+          Name: displayNameWithoutComma(row.name),
+          Status:
+            row.importedFromTemplate
+              ? "-"
+              : row.status === "approved"
+                ? "Approved"
+                : row.status === "rejected"
+                  ? "Rejected"
+                  : "Pending",
+          "Total Work Hours": roundToOneDecimal(row.hours),
+          Confirmation: !row.importedFromTemplate && row.status === "approved" ? "Confirmed" : "Unconfirmed",
+          "Distributed Time": submittedTimeById(row.id),
+          "Distributed By": row.operatedBy?.trim() || "—",
+          Department: row.department,
+          Title: row.title,
+          "Target Teaching Ratio": row.targetTeachingRatio != null ? `${roundToOneDecimal(row.targetTeachingRatio)}%` : "50.0%",
+          "Actual Teaching Ratio": row.detailSnapshot?.actualTeachingRatioDisplay ?? "-",
+          "Employment Type": row.detailSnapshot?.employmentType ?? (row.hours >= 800 ? "Full-time" : "Part-time"),
+          "New Staff": row.workloadNewStaff ? "Yes" : "No",
+          "HoD Review": row.hodReview === "yes" ? "Yes" : "No",
+          "School of Operations Notes": workloadModalNotes(row),
+        }));
+      if (!semesterRows.length) return;
+      newReports.push({
+        id: `ops-report-${year}-${semester}-${Date.now()}`,
+        year,
+        semester,
+        title: `${year} ${semester} distribution report generated`,
+        createdAt: new Date().toISOString(),
+        rows: semesterRows,
+      });
+    });
 
-    window.addEventListener("storage", onStorage);
-    window.addEventListener(ACADEMIC_DRAFT_EVENT, onDraftEvent as EventListener);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      window.removeEventListener(ACADEMIC_DRAFT_EVENT, onDraftEvent as EventListener);
-    };
+    if (!newReports.length) return;
+    const next = [...newReports, ...existing].sort(
+      (a, b) => Date.parse(b.createdAt || "") - Date.parse(a.createdAt || "")
+    );
+    writeOpsSemesterReports(next);
+    setOpsSemesterReports(next);
+  }, [pending]);
+
+  useEffect(() => {
+    if (!opsReportInboxOpen) return;
+    setOpsSemesterReports((prev) => {
+      const now = new Date().toISOString();
+      const next = prev.map((item) => (item.readAt ? item : { ...item, readAt: now }));
+      writeOpsSemesterReports(next);
+      return next;
+    });
+  }, [opsReportInboxOpen]);
+
+  useEffect(() => {
+    // Test helper: keep at least 2 inbox rows for UI verification.
+    setOpsSemesterReports((prev) => {
+      if (prev.length !== 1) return prev;
+      if (prev.some((item) => item.id.includes("-demo-copy"))) return prev;
+      const base = prev[0];
+      const copied: OpsSemesterReportItem = {
+        ...base,
+        id: `${base.id}-demo-copy`,
+        title: `${base.year} ${base.semester} distribution report generated (copy)`,
+        createdAt: new Date(Date.parse(base.createdAt || "") - 60_000).toISOString(),
+        readAt: undefined,
+      };
+      const next = [base, copied].sort(
+        (a, b) => Date.parse(b.createdAt || "") - Date.parse(a.createdAt || "")
+      );
+      writeOpsSemesterReports(next);
+      return next;
+    });
   }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(SUPERVISOR_STATE_KEY, JSON.stringify(pending));
-  }, [pending]);
+    const total = Math.max(1, Math.ceil(opsSemesterReports.length / 10));
+    setOpsReportInboxPage((prev) => Math.min(Math.max(1, prev), total));
+  }, [opsSemesterReports.length]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    const sync: Record<string, "pending" | "approved" | "rejected"> = {};
-    const notesSync: Record<string, string> = {};
-    pending.forEach((row) => {
-      if (row.studentId) sync[row.studentId] = row.status;
-      if (row.studentId && row.supervisorNote) notesSync[row.studentId] = row.supervisorNote;
-    });
-    window.localStorage.setItem(ACADEMIC_STATUS_SYNC_KEY, JSON.stringify(sync));
-    window.localStorage.setItem(ACADEMIC_NOTES_SYNC_KEY, JSON.stringify(notesSync));
-    window.dispatchEvent(new Event(SUPERVISOR_SYNC_EVENT));
-  }, [pending]);
+    function syncFromSupervisor() {
+      setAcademicStatusSyncMap(readAcademicStatusSync());
+    }
+    function onStorage(e: StorageEvent) {
+      if (e.key === ACADEMIC_STATUS_SYNC_KEY) syncFromSupervisor();
+    }
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(SUPERVISOR_SYNC_EVENT, syncFromSupervisor as EventListener);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(SUPERVISOR_SYNC_EVENT, syncFromSupervisor as EventListener);
+    };
+  }, []);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [page, setPage] = useState(1);
   const pageSize = 10; // Items per page
@@ -1178,6 +1266,28 @@ export default function SchoolofOperations() {
     () => Array.from({ length: 11 }, (_, i) => String(selectedYear - 5 + i)),
     [selectedYear]
   );
+  const opsReportsPerPage = 10;
+  const opsUnreadReportCount = useMemo(
+    () => opsSemesterReports.filter((item) => !item.readAt).length,
+    [opsSemesterReports]
+  );
+  const opsReportTotalPages = Math.max(1, Math.ceil(opsSemesterReports.length / opsReportsPerPage));
+  const pagedOpsReports = useMemo(() => {
+    const start = (opsReportInboxPage - 1) * opsReportsPerPage;
+    return opsSemesterReports.slice(start, start + opsReportsPerPage);
+  }, [opsSemesterReports, opsReportInboxPage]);
+
+  function semesterEndDate(year: number, semester: "S1" | "S2"): Date {
+    return semester === "S1" ? new Date(year, 5, 30, 23, 59, 59, 999) : new Date(year, 11, 31, 23, 59, 59, 999);
+  }
+
+  function handleDownloadOpsSemesterReport(report: OpsSemesterReportItem) {
+    if (!report.rows.length) return;
+    const ws = XLSX.utils.json_to_sheet(report.rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, `${report.year}-${report.semester}`);
+    XLSX.writeFile(wb, `workload_report_${report.year}_${report.semester}.xlsx`);
+  }
 
   const adminModalBreakdown = useMemo(() => {
     if (!detailsItem) return null;
@@ -1437,19 +1547,6 @@ export default function SchoolofOperations() {
     [detailsComputedTotalHours, totalHoursWorkingDaysSuffix]
   );
 
-  useEffect(() => {
-    // User-requested reset: clear current School Operations workload data and import caches.
-    setPending([]);
-    setSelectedIds(new Set());
-    setWorkloadTeachingImportLinesByStaffId({});
-    setWorkloadHdrImportByStaffId({});
-    setWorkloadServiceImportByStaffId({});
-    setWorkloadAssignedRoleImportByStaffId({});
-    setWorkloadAnomalyImportByStaffId({});
-    window.localStorage.removeItem(SUPERVISOR_STATE_KEY);
-    window.localStorage.removeItem(SUPERVISOR_DRAFT_KEY);
-  }, []);
-
   const itemsForFilter = useMemo(() => {
     const byStatus = pending.filter((it) => {
       if (statusFilter === "all") return !it.cancelled && it.status === "pending";
@@ -1528,6 +1625,16 @@ export default function SchoolofOperations() {
     workloadServiceImportByStaffId,
   ]);
 
+  function displayStatusForOpsRow(row: MockRequest): "pending" | "approved" | "rejected" | "-" {
+    if (row.cancelled) return row.status;
+    if (row.importedFromTemplate && row.status === "pending") return "-";
+    if (row.status !== "approved") return row.status;
+    const synced = academicStatusSyncMap[String(row.id)];
+    // Distributed to Academic but not submitted yet: keep initialization marker.
+    if (!synced) return "-";
+    return synced;
+  }
+
   const pendingFilteredIds = useMemo(() => itemsForFilter.map((it) => it.id), [itemsForFilter]);
   const allPendingFilteredSelected =
     pendingFilteredIds.length > 0 && pendingFilteredIds.every((id) => selectedIds.has(id));
@@ -1594,7 +1701,7 @@ export default function SchoolofOperations() {
     const rows = itemsForFilter.map((it) => ({
       Name: it.name,
       "Staff Number": it.studentId,
-      Status: it.status,
+      Status: displayStatusForOpsRow(it),
       "Hours out of band (import)": it.importedFromTemplate
         ? isImportedRowHoursOutOfBand(it, workloadAnomalyImportByStaffId)
           ? "Yes"
@@ -1642,8 +1749,8 @@ export default function SchoolofOperations() {
     const rows = itemsForFilter.map((it) => ({
       Name: it.name,
       "Staff Number": it.studentId,
-      Status: it.status,
-      Confirmation: it.status === "approved" ? "Confirmed" : "Unconfirmed",
+      Status: displayStatusForOpsRow(it),
+      Confirmation: displayStatusForOpsRow(it) === "approved" ? "Confirmed" : "Unconfirmed",
       "Total work hours": roundToOneDecimal(it.hours),
       "Distributed time": submittedTimeById(it.id),
       "Distributed by": it.operatedBy?.trim() ? it.operatedBy : "—",
@@ -2121,6 +2228,27 @@ export default function SchoolofOperations() {
       });
       if (typeof window !== "undefined") {
         window.localStorage.setItem(OPS_ACADEMIC_DISTRIBUTED_KEY, JSON.stringify(next));
+        // New distribution should always start from "-" on Academic/OPS until Academic submits.
+        const statusRaw = window.localStorage.getItem(ACADEMIC_STATUS_SYNC_KEY);
+        const statusMap =
+          statusRaw && typeof statusRaw === "string"
+            ? (JSON.parse(statusRaw) as Record<string, "pending" | "approved" | "rejected">)
+            : {};
+        const notesRaw = window.localStorage.getItem(ACADEMIC_NOTES_SYNC_KEY);
+        const notesMap =
+          notesRaw && typeof notesRaw === "string"
+            ? (JSON.parse(notesRaw) as Record<string, string>)
+            : {};
+        selectedPendingRows.forEach((row) => {
+          if (!approvedSelectedIds.has(row.id)) return;
+          delete statusMap[String(row.id)];
+          if (row.studentId) delete statusMap[row.studentId.trim()];
+          delete notesMap[String(row.id)];
+          if (row.studentId) delete notesMap[row.studentId.trim()];
+        });
+        window.localStorage.setItem(ACADEMIC_STATUS_SYNC_KEY, JSON.stringify(statusMap));
+        window.localStorage.setItem(ACADEMIC_NOTES_SYNC_KEY, JSON.stringify(notesMap));
+        window.dispatchEvent(new Event(SUPERVISOR_SYNC_EVENT));
       }
       return next;
     });
@@ -2276,8 +2404,6 @@ export default function SchoolofOperations() {
       { header: "title", key: "title", width: 18 },
       { header: "department", key: "department", width: 40 },
       { header: "active_status", key: "active_status", width: 16 },
-      { header: "is_new_employee", key: "is_new_employee", width: 18 },
-      { header: "notes", key: "notes", width: 52 },
     ];
 
     const headerRow = worksheet.getRow(1);
@@ -2304,8 +2430,6 @@ export default function SchoolofOperations() {
       title: "Lecturer",
       department: "Physics",
       active_status: "Active",
-      is_new_employee: "false",
-      notes: "",
     });
 
     // Apply data validation to a practical import range.
@@ -2360,14 +2484,6 @@ export default function SchoolofOperations() {
         showErrorMessage: true,
         errorTitle: "Invalid Active Status",
         error: "Active Status must be Active or Inactive.",
-      };
-      worksheet.getCell(`H${row}`).dataValidation = {
-        type: "list",
-        allowBlank: true,
-        formulae: ['"true,false"'],
-        showErrorMessage: true,
-        errorTitle: "Invalid is_new_employee",
-        error: "Use true or false — leave blank for false.",
       };
     }
 
@@ -2953,11 +3069,82 @@ export default function SchoolofOperations() {
       <div className="mx-auto max-w-7xl px-3 pb-10 pt-8">
         <DashboardHeader
           title="School Operations Dashboard"
-          showMessageButton={false}
+          hasNewMessage={opsUnreadReportCount > 0}
+          onMessageClick={() => setOpsReportInboxOpen(true)}
           greetingName={user.surname}
           onAvatarClick={() => setProfileOpen(true)}
           avatarSrc={avatarSrc}
         />
+
+        {opsReportInboxOpen && (
+          <div
+            className="fixed inset-0 z-[70] flex items-center justify-center bg-black/30 p-4"
+            onClick={() => setOpsReportInboxOpen(false)}
+          >
+            <div
+              className="w-full max-w-3xl rounded-2xl border-2 border-[#2f4d9c] bg-slate-50 p-6 shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="-mx-6 -mt-6 mb-4 flex items-center justify-between rounded-t-2xl bg-[#2f4d9c] px-6 py-4 text-white">
+                <div className="text-2xl font-semibold">Semester Distribution Reports</div>
+                <button
+                  type="button"
+                  aria-label="Close report inbox"
+                  className="rounded p-1 text-white/90 hover:bg-white/20"
+                  onClick={() => setOpsReportInboxOpen(false)}
+                >
+                  ✕
+                </button>
+              </div>
+              {opsSemesterReports.length === 0 ? (
+                <div className="rounded-md border border-[#2f4d9c]/30 bg-white px-4 py-5 text-sm text-slate-700">
+                  No semester report generated yet.
+                </div>
+              ) : (
+                <>
+                  <div className="max-h-80 overflow-y-auto rounded-md border border-[#2f4d9c]/40 bg-white">
+                    {pagedOpsReports.map((report) => (
+                      <div
+                        key={report.id}
+                        className="flex items-center justify-between gap-3 border-b border-[#2f4d9c]/10 px-4 py-3"
+                      >
+                        <div className="text-sm font-semibold text-slate-800">{report.title}</div>
+                        <button
+                          type="button"
+                          onClick={() => handleDownloadOpsSemesterReport(report)}
+                          className="inline-flex items-center gap-2 rounded border border-[#2f4d9c]/40 bg-[#eef3ff] px-3 py-1 text-xs font-semibold text-[#2f4d9c] hover:bg-[#e0e9ff]"
+                        >
+                          ⬇ Download
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between px-1 text-sm">
+                    <button
+                      type="button"
+                      onClick={() => setOpsReportInboxPage((p) => Math.max(1, p - 1))}
+                      disabled={opsReportInboxPage <= 1}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Previous
+                    </button>
+                    <span className="text-slate-600">
+                      Page {opsReportInboxPage} / {opsReportTotalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setOpsReportInboxPage((p) => Math.min(opsReportTotalPages, p + 1))}
+                      disabled={opsReportInboxPage >= opsReportTotalPages}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Next
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
 
         <ProfileModal
           open={profileOpen}
@@ -3273,6 +3460,7 @@ export default function SchoolofOperations() {
                           const isSelected = selectedIds.has(item.id);
                           const rowCancelled = Boolean(item.cancelled);
                           const rowIndex = (page - 1) * pageSize + idx + 1;
+                          const opsDisplayStatus = displayStatusForOpsRow(item);
                           return (
                             <tr
                               key={item.id}
@@ -3314,17 +3502,17 @@ export default function SchoolofOperations() {
                                 <div className="text-xs text-slate-400">{item.studentId}</div>
                               </td>
                               <td className="px-3 py-3 text-center">
-                                {item.importedFromTemplate ? (
+                                {opsDisplayStatus === "-" ? (
                                   <span className="text-sm font-semibold text-slate-500">-</span>
                                 ) : (
-                                  <StatusPill status={item.status} variant="supervisor" />
+                                  <StatusPill status={opsDisplayStatus} variant="supervisor" />
                                 )}
                               </td>
                               <td className="px-3 py-3 text-center">
                                 <WorkHoursBadge hours={roundToOneDecimal(item.hours)} />
                               </td>
                               <td className="px-3 py-3">
-                                {!item.importedFromTemplate && item.status === "approved" ? (
+                                {opsDisplayStatus === "approved" ? (
                                   <span className="inline-flex items-center gap-2 text-xs font-semibold text-[#15803d]">
                                     <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#15803d] bg-[#15803d] text-[10px] text-white">
                                       ✓

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -3626,24 +3626,25 @@ export default function SchoolofOperations() {
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className="rounded-sm border border-black">
-                      <div className="flex items-center justify-between gap-4 border-b border-black/30 bg-white px-5 py-3">
+                      <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
                         <div className="flex items-center gap-3">
-                          <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
                             {workloadDetailReportingPeriodLabel(detailsItem)}
                           </div>
-                          <div className="rounded-sm bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
                             {detailsItem.department?.trim() || "Department N/A"}
                           </div>
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                            Academic
+                          </div>
                         </div>
-                        <div className="flex items-center gap-3 text-sm font-semibold text-slate-800">
-                          <button
-                            type="button"
-                            onClick={closeDetails}
-                            className="rounded bg-slate-200 px-3 py-1 text-xs font-bold text-slate-700 hover:bg-slate-300"
-                          >
-                            Close
-                          </button>
-                        </div>
+                        <button
+                          type="button"
+                          onClick={closeDetails}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-white/10 hover:bg-white/20"
+                        >
+                          <span className="text-xl leading-none">×</span>
+                        </button>
                       </div>
 
                       <div className="space-y-4 px-5 py-4">

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -3627,16 +3627,8 @@ export default function SchoolofOperations() {
                   >
                     <div className="rounded-sm border border-black">
                       <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
-                        <div className="flex items-center gap-3">
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                            {workloadDetailReportingPeriodLabel(detailsItem)}
-                          </div>
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                            {detailsItem.department?.trim() || "Department N/A"}
-                          </div>
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                            Academic
-                          </div>
+                        <div className="text-lg font-bold">
+                          {`${workloadDetailReportingPeriodLabel(detailsItem)}-${detailsItem.department?.trim() || "Department N/A"}-Academic`}
                         </div>
                         <button
                           type="button"

--- a/frontend/src/pages/HeadofSchool.tsx
+++ b/frontend/src/pages/HeadofSchool.tsx
@@ -18,7 +18,6 @@ import ExcelJS from "exceljs";
 import * as XLSX from "xlsx";
 import DashboardHeader from "../components/common/DashboardHeader";
 import FilterFormRow from "../components/common/FilterFormRow";
-import InfoField from "../components/common/InfoField";
 import PaginationControls from "../components/common/PaginationControls";
 import ProfileModal from "../components/common/ProfileModal";
 import SearchButton from "../components/common/SearchButton";
@@ -51,7 +50,7 @@ type MockRequest = {
   cancelled?: boolean;
 };
 
-type BreakdownCategory = "Teaching" | "Assigned Roles" | "HDR" | "Service";
+type BreakdownCategory = "Teaching" | "Assigned Roles" | "HDR" | "Service" | "Research (residual)";
 type BreakdownEntry = { name: string; hours: number };
 type BreakdownData = Record<BreakdownCategory, BreakdownEntry[]>;
 
@@ -62,6 +61,44 @@ const ACADEMIC_STATUS_SYNC_KEY = "academic_status_sync_v1";
 const ACADEMIC_NOTES_SYNC_KEY = "academic_notes_sync_v1";
 const SUPERVISOR_SYNC_EVENT = "supervisor-status-updated";
 const ACADEMIC_DRAFT_EVENT = "academic-drafts-updated";
+const HOS_SEMESTER_REPORTS_KEY = "hos_semester_report_inbox_v1";
+
+type HosSemesterReportItem = {
+  id: string;
+  year: number;
+  semester: "S1" | "S2";
+  title: string;
+  createdAt: string;
+  readAt?: string;
+  isDemo?: boolean;
+  rows: Record<string, string | number>[];
+};
+
+function readHosSemesterReports(): HosSemesterReportItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(HOS_SEMESTER_REPORTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as HosSemesterReportItem[];
+  } catch {
+    return [];
+  }
+}
+
+function writeHosSemesterReports(items: HosSemesterReportItem[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(HOS_SEMESTER_REPORTS_KEY, JSON.stringify(items));
+}
+
+function displayNameWithoutComma(raw: string): string {
+  return raw.replace(/,/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function reportStatusText(status: MockRequest["status"]) {
+  return status === "approved" ? "Approved" : status === "rejected" ? "Rejected" : "Pending";
+}
 
 function submittedTimeById(id: number) {
   const day = ((id - 1) % 28) + 1;
@@ -126,6 +163,7 @@ function breakdownById(id: number): BreakdownData {
         { name: "Student B", hours: 2 },
       ],
       Service: [{ name: "Committee support", hours: 10 }],
+      "Research (residual)": [{ name: "Research (residual)", hours: 0 }],
     },
     {
       Teaching: [{ name: "CITS3002", hours: 15 }],
@@ -135,6 +173,7 @@ function breakdownById(id: number): BreakdownData {
         { name: "Student E", hours: 2 },
       ],
       Service: [{ name: "Peer review", hours: 4 }],
+      "Research (residual)": [{ name: "Research (residual)", hours: 0 }],
     },
   ];
   return patterns[id % patterns.length];
@@ -160,6 +199,65 @@ function workloadModalNotes(row: Pick<MockRequest, "notes" | "description">) {
   return cleanDescription(row.description ?? "");
 }
 
+function requestReasonText(row: Pick<MockRequest, "requestReason" | "description">) {
+  return row.requestReason?.trim() || extractRequestReason(row.description ?? "").trim();
+}
+
+function buildHosSemesterReportRows(rows: MockRequest[]) {
+  return rows.map((row) => ({
+    "Staff ID": row.studentId,
+    Name: displayNameWithoutComma(row.name),
+    Department: row.department,
+    Title: row.title,
+    Status: reportStatusText(row.status),
+    "Total Work Hours": row.hours,
+    "Submitted Time": submittedTimeById(row.id),
+    "Application Reason": requestReasonText(row) || "—",
+    "HoS Review Note": row.supervisorNote?.trim() || "—",
+  }));
+}
+
+function createHosSemesterDemoReport(): HosSemesterReportItem {
+  return {
+    id: "hos-report-demo-2025-S1",
+    year: 2025,
+    semester: "S1",
+    title: "2025 S1 distribution report generated",
+    createdAt: "2025-07-01T09:00:00.000Z",
+    readAt: undefined,
+    isDemo: true,
+    rows: [
+      {
+        "Staff ID": "12345931",
+        Name: "Dias John",
+        Department: "Physics",
+        Title: "Lecturer",
+        Status: "Pending",
+        "Total Work Hours": 793.5,
+        "Submitted Time": "2025-06-24 10:00",
+        "Application Reason": "wrong",
+        "HoS Review Note": "—",
+      },
+    ],
+  };
+}
+
+/** Last name, first name, or full name (substring or order-independent tokens; commas as spaces). */
+function workloadNameSearchMatches(recordName: string, queryRaw: string): boolean {
+  const q = queryRaw.trim().toLowerCase();
+  if (!q) return true;
+  const norm = recordName
+    .toLowerCase()
+    .replace(/,/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!norm) return false;
+  if (norm.includes(q)) return true;
+  const qTokens = q.split(/\s+/).filter(Boolean);
+  const parts = norm.split(" ").filter(Boolean);
+  return qTokens.every((t) => parts.some((p) => p.includes(t)));
+}
+
 function shortDepartmentName(department: string) {
   if (department === "Computer Science & Software Engineering") return "CS&SE";
   if (department === "Mathematics & Statistics") return "Math&Stats";
@@ -178,13 +276,14 @@ function maxValue(values: number[]) {
   return Math.max(...values);
 }
 
+/** Workload search filter: school departments (org chart). */
+const WORKLOAD_SEARCH_DEPARTMENT_OPTIONS = [
+  "Physics",
+  "Mathematics & Statistics",
+  "Computer Science & Software Engineering",
+] as const;
+
 export default function HeadofSchool() {
-  type ChatMessage = {
-    sender: "Sam" | "Admin";
-    message: string;
-    time: string;
-    date: string;
-  };
   type AssignRole = "HoD" | "Admin";
   type AssignDepartment =
     | "Physics"
@@ -217,19 +316,13 @@ export default function HeadofSchool() {
 
   const user = MOCK_DASHBOARD_USER;
 
-  const [hasNewMessage, setHasNewMessage] = useState(true);
-  const [messagePanelOpen, setMessagePanelOpen] = useState(false);
+  const [hosReportInboxOpen, setHosReportInboxOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   const [avatarSrc, setAvatarSrc] = useState<string | null>(null);
-  const [chatInput, setChatInput] = useState("");
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([
-    { sender: "Sam", message: "I have a question about workload item #11.", time: "09:10", date: "2026-04-22" },
-    { sender: "Admin", message: "Please check the teaching hours again.", time: "09:16", date: "2026-04-22" },
-    { sender: "Sam", message: "Thank you, I will update it.", time: "09:18", date: "2026-04-23" },
-  ]);
-  const [selectedChatDate, setSelectedChatDate] = useState("2026-04-23");
-  const [calendarOpen, setCalendarOpen] = useState(false);
-  const [calendarMonth, setCalendarMonth] = useState("2026-04");
+  const [hosSemesterReports, setHosSemesterReports] = useState<HosSemesterReportItem[]>(() =>
+    readHosSemesterReports()
+  );
+  const [hosReportInboxPage, setHosReportInboxPage] = useState(1);
   const [activeSection, setActiveSection] = useState<
     "approval" | "admin" | "visualization" | "export"
   >("approval");
@@ -239,11 +332,6 @@ export default function HeadofSchool() {
     { key: "visualization", label: "Visualization" },
     { key: "export", label: "Export Excel" },
   ];
-  const availableChatDates = useMemo(() => new Set(chatHistory.map((entry) => entry.date)), [chatHistory]);
-  const visibleChatHistory = useMemo(
-    () => chatHistory.filter((entry) => entry.date === selectedChatDate),
-    [chatHistory, selectedChatDate]
-  );
   const currentYear = useMemo(() => new Date().getFullYear(), []);
 
   const [loading] = useState(false);
@@ -315,25 +403,23 @@ export default function HeadofSchool() {
   const [detailsItem, setDetailsItem] = useState<MockRequest | null>(null);
   const [detailsBreakdown, setDetailsBreakdown] = useState<BreakdownData | null>(null);
   const [detailsTab, setDetailsTab] = useState<BreakdownCategory>("Teaching");
+  const [detailsEditMode, setDetailsEditMode] = useState(false);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [noteModalOpen, setNoteModalOpen] = useState(false);
   const [noteDraft, setNoteDraft] = useState("");
   const [noteError, setNoteError] = useState("");
+  const [detailsModalError, setDetailsModalError] = useState("");
   const [noteDecision, setNoteDecision] = useState<"approve" | "reject">("approve");
   const [noteTargetId, setNoteTargetId] = useState<number | null>(null);
 
   const [searchEmployeeIdInput, setSearchEmployeeIdInput] = useState("");
-  const [searchLastNameInput, setSearchLastNameInput] = useState("");
-  const [searchFirstNameInput, setSearchFirstNameInput] = useState("");
-  const [searchTitleInput, setSearchTitleInput] = useState("");
+  const [searchNameInput, setSearchNameInput] = useState("");
   const [searchDepartmentInput, setSearchDepartmentInput] = useState("");
   const [searchYearInput, setSearchYearInput] = useState("");
   const [searchSemesterInput, setSearchSemesterInput] = useState<"" | "S1" | "S2">("");
   const [searchFilters, setSearchFilters] = useState({
     employeeId: "",
-    lastName: "",
-    firstName: "",
-    title: "",
+    name: "",
     department: "",
     year: "",
     semester: "",
@@ -421,6 +507,108 @@ export default function HeadofSchool() {
     () => Array.from({ length: 11 }, (_, i) => String(selectedYear - 5 + i)),
     [selectedYear]
   );
+  const hosReportsPerPage = 10;
+  const hosUnreadReportCount = useMemo(
+    () => hosSemesterReports.filter((item) => !item.readAt).length,
+    [hosSemesterReports]
+  );
+  const hosReportTotalPages = Math.max(1, Math.ceil(hosSemesterReports.length / hosReportsPerPage));
+  const pagedHosReports = useMemo(() => {
+    const start = (hosReportInboxPage - 1) * hosReportsPerPage;
+    return hosSemesterReports.slice(start, start + hosReportsPerPage);
+  }, [hosSemesterReports, hosReportInboxPage]);
+
+  function semesterReportAvailableOn(year: number, semester: "S1" | "S2"): Date {
+    return semester === "S1" ? new Date(year, 6, 1, 0, 0, 0, 0) : new Date(year + 1, 0, 1, 0, 0, 0, 0);
+  }
+
+  function handleDownloadHosSemesterReport(report: HosSemesterReportItem) {
+    if (!report.rows.length) return;
+    const ws = XLSX.utils.json_to_sheet(report.rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, `${report.year}-${report.semester}`);
+    XLSX.writeFile(wb, `hos_distribution_report_${report.year}_${report.semester}.xlsx`);
+  }
+
+  useEffect(() => {
+    setHosSemesterReports((prev) => {
+      const base = (prev.length ? prev : readHosSemesterReports()).map((item) => ({
+        ...item,
+        title: `${item.year} ${item.semester} distribution report generated`,
+      }));
+      if (base.length) {
+        writeHosSemesterReports(base);
+        return base;
+      }
+      const seeded = [createHosSemesterDemoReport()];
+      writeHosSemesterReports(seeded);
+      return seeded;
+    });
+  }, []);
+
+  useEffect(() => {
+    const now = new Date();
+    const existing = readHosSemesterReports();
+    const existingByKey = new Map<string, HosSemesterReportItem>(
+      existing.map((item) => [`${item.year}-${item.semester}`, item] as const)
+    );
+    const semesterKeys = new Set<string>();
+
+    pending.forEach((row) => {
+      if (row.cancelled) return;
+      const matched = row.periodLabel.match(/^(\d{4})-(1|2)$/);
+      if (!matched) return;
+      const year = Number(matched[1]);
+      const semester = matched[2] === "1" ? "S1" : "S2";
+      if (now < semesterReportAvailableOn(year, semester)) return;
+      semesterKeys.add(`${year}-${semester}`);
+    });
+
+    const newReports: HosSemesterReportItem[] = [];
+    const replacedDemoKeys = new Set<string>();
+    semesterKeys.forEach((key) => {
+      const existingItem = existingByKey.get(key);
+      if (existingItem && !existingItem.isDemo) return;
+      const [yearText, semester] = key.split("-") as [string, "S1" | "S2"];
+      const year = Number(yearText);
+      const semesterRows = buildHosSemesterReportRows(
+        pending.filter((row) => !row.cancelled && row.periodLabel === `${year}-${semester === "S1" ? "1" : "2"}`)
+      );
+      if (!semesterRows.length) return;
+      if (existingItem?.isDemo) replacedDemoKeys.add(key);
+      newReports.push({
+        id: `hos-report-${year}-${semester}-${Date.now()}`,
+        year,
+        semester,
+        title: `${year} ${semester} distribution report generated`,
+        createdAt: new Date().toISOString(),
+        rows: semesterRows,
+      });
+    });
+
+    if (!newReports.length) return;
+    const retainedExisting = existing.filter((item) => !replacedDemoKeys.has(`${item.year}-${item.semester}`));
+    const next = [...newReports, ...retainedExisting].sort(
+      (a, b) => Date.parse(b.createdAt || "") - Date.parse(a.createdAt || "")
+    );
+    writeHosSemesterReports(next);
+    setHosSemesterReports(next);
+  }, [pending]);
+
+  useEffect(() => {
+    if (!hosReportInboxOpen) return;
+    setHosSemesterReports((prev) => {
+      const now = new Date().toISOString();
+      const next = prev.map((item) => (item.readAt ? item : { ...item, readAt: now }));
+      writeHosSemesterReports(next);
+      return next;
+    });
+  }, [hosReportInboxOpen]);
+
+  useEffect(() => {
+    const total = Math.max(1, Math.ceil(hosSemesterReports.length / hosReportsPerPage));
+    setHosReportInboxPage((prev) => Math.min(Math.max(1, prev), total));
+  }, [hosSemesterReports.length]);
 
   const pendingCount = useMemo(
     () => pending.filter((it) => it.status === "pending").length,
@@ -437,11 +625,6 @@ export default function HeadofSchool() {
     if (!hasSearchFilter) return byStatus;
 
     return byStatus.filter((it) => {
-      const fullName = it.name.toLowerCase();
-      const nameParts = it.name.trim().toLowerCase().split(/\s+/);
-      const firstName = nameParts[0] || "";
-      const lastName = nameParts[nameParts.length - 1] || "";
-
       if (
         searchFilters.employeeId &&
         !it.studentId.toLowerCase().includes(searchFilters.employeeId)
@@ -449,15 +632,7 @@ export default function HeadofSchool() {
         return false;
       }
 
-      if (searchFilters.firstName && !firstName.includes(searchFilters.firstName)) {
-        return false;
-      }
-
-      if (searchFilters.lastName && !lastName.includes(searchFilters.lastName)) {
-        return false;
-      }
-
-      if (searchFilters.title && !it.title.toLowerCase().includes(searchFilters.title)) {
+      if (searchFilters.name && !workloadNameSearchMatches(it.name, searchFilters.name)) {
         return false;
       }
 
@@ -490,7 +665,7 @@ export default function HeadofSchool() {
         }
       }
 
-      return fullName.length > 0;
+      return it.name.trim().length > 0;
     });
   }, [pending, statusFilter, searchFilters]);
   const adminSearchResults = useMemo(() => {
@@ -753,13 +928,6 @@ export default function HeadofSchool() {
     });
   }
 
-  function statusLabel(status: string) {
-    if (status === "pending") return "Pending";
-    if (status === "approved") return "Approved";
-    if (status === "rejected") return "Rejected";
-    return status;
-  }
-
   const canSubmit =
     statusFilter === "pending" && selectedIds.size > 0 && !submitting;
 
@@ -829,6 +997,15 @@ export default function HeadofSchool() {
   }
 
   function openNoteModal(kind: "approve" | "reject", id: number) {
+    if (detailsBreakdown) {
+      const hasEmptyRow = (Object.keys(detailsBreakdown) as BreakdownCategory[]).some((tab) =>
+        detailsBreakdown[tab].some((row) => row.name.trim() === "")
+      );
+      if (hasEmptyRow) {
+        setDetailsModalError("Empty breakdown rows must be completed or deleted first.");
+        return;
+      }
+    }
     setNoteDecision(kind);
     setNoteTargetId(id);
     setNoteDraft("");
@@ -855,9 +1032,7 @@ export default function HeadofSchool() {
   function handleSearch() {
     setSearchFilters({
       employeeId: searchEmployeeIdInput.trim().toLowerCase(),
-      lastName: searchLastNameInput.trim().toLowerCase(),
-      firstName: searchFirstNameInput.trim().toLowerCase(),
-      title: searchTitleInput.trim().toLowerCase(),
+      name: searchNameInput.trim().toLowerCase(),
       department: searchDepartmentInput.trim().toLowerCase(),
       year: searchYearInput.trim().toLowerCase(),
       semester: searchSemesterInput.trim().toLowerCase(),
@@ -1259,13 +1434,30 @@ export default function HeadofSchool() {
     setDetailsItem(item);
     setDetailsBreakdown(breakdownById(item.id));
     setDetailsOpen(true);
+    setDetailsEditMode(false);
     setDescriptionExpanded(false);
+    setDetailsModalError("");
+  }
+
+  function requestCloseDetails() {
+    if (detailsEditMode && detailsBreakdown) {
+      const hasEmptyRow = (Object.keys(detailsBreakdown) as BreakdownCategory[]).some((tab) =>
+        detailsBreakdown[tab].some((row) => row.name.trim() === "")
+      );
+      if (hasEmptyRow) {
+        setDetailsModalError("Empty breakdown rows must be completed or deleted before closing.");
+        return;
+      }
+    }
+    closeDetails();
   }
 
   function closeDetails() {
     setDetailsOpen(false);
     setDetailsItem(null);
     setDetailsBreakdown(null);
+    setDetailsEditMode(false);
+    setDetailsModalError("");
     setNoteModalOpen(false);
     setNoteDraft("");
     setNoteError("");
@@ -1273,6 +1465,7 @@ export default function HeadofSchool() {
   }
 
   function updateBreakdownRow(tab: BreakdownCategory, idx: number, field: "name" | "hours", value: string) {
+    setDetailsModalError("");
     setDetailsBreakdown((prev) => {
       if (!prev) return prev;
       const nextRows = prev[tab].map((row, rowIdx) => {
@@ -1286,11 +1479,28 @@ export default function HeadofSchool() {
     });
   }
 
-  function handleYearWheel(event: React.WheelEvent<HTMLSelectElement>) {
-    event.preventDefault();
-    const delta = event.deltaY > 0 ? 1 : -1;
-    const nextYear = (Number(searchYearInput) || currentYear) + delta;
-    setSearchYearInput(String(nextYear));
+  function addBreakdownRow(tab: BreakdownCategory) {
+    setDetailsModalError("");
+    setDetailsBreakdown((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [tab]: [...prev[tab], { name: "", hours: 0 }],
+      };
+    });
+  }
+
+  function removeBreakdownRow(tab: BreakdownCategory, idx: number) {
+    setDetailsModalError("");
+    setDetailsBreakdown((prev) => {
+      if (!prev) return prev;
+      const currentRows = prev[tab];
+      if (currentRows.length <= 1) return prev;
+      return {
+        ...prev,
+        [tab]: currentRows.filter((_, rowIdx) => rowIdx !== idx),
+      };
+    });
   }
 
   function handleSearchKeyDown(event: React.KeyboardEvent<HTMLInputElement | HTMLSelectElement>) {
@@ -1298,27 +1508,6 @@ export default function HeadofSchool() {
       event.preventDefault();
       handleSearch();
     }
-  }
-
-  function openMessagePanel() {
-    setMessagePanelOpen(true);
-    setHasNewMessage(false);
-  }
-
-  function handleSendMessage() {
-    const trimmed = chatInput.trim();
-    if (!trimmed) return;
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, "0");
-    const mm = String(now.getMinutes()).padStart(2, "0");
-    const today = now.toISOString().slice(0, 10);
-    setChatHistory((prev) => [
-      ...prev,
-      { sender: "Sam", message: trimmed, time: `${hh}:${mm}`, date: today },
-    ]);
-    setSelectedChatDate(today);
-    setCalendarMonth(today.slice(0, 7));
-    setChatInput("");
   }
 
   function handleAvatarUpload(event: ChangeEvent<HTMLInputElement>) {
@@ -1333,164 +1522,84 @@ export default function HeadofSchool() {
     event.target.value = "";
   }
 
-  function changeCalendarMonth(offset: number) {
-    const [yearStr, monthStr] = calendarMonth.split("-");
-    const date = new Date(Number(yearStr), Number(monthStr) - 1 + offset, 1);
-    setCalendarMonth(
-      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`
-    );
-  }
-
   return (
     <div className="min-h-screen bg-[#f3f4f6] font-serif">
       <div className="mx-auto max-w-7xl px-3 pb-10 pt-8">
         <DashboardHeader
           title="HoS Dashboard"
-          hasNewMessage={hasNewMessage}
-          onMessageClick={openMessagePanel}
+          hasNewMessage={hosUnreadReportCount > 0}
+          onMessageClick={() => setHosReportInboxOpen(true)}
           greetingName={user.surname}
           onAvatarClick={() => setProfileOpen(true)}
           avatarSrc={avatarSrc}
         />
 
-        {messagePanelOpen && (
+        {hosReportInboxOpen && (
           <div
             className="fixed inset-0 z-[70] flex items-center justify-center bg-black/30 p-4"
-            onClick={() => setMessagePanelOpen(false)}
+            onClick={() => setHosReportInboxOpen(false)}
           >
             <div
-              className="w-full max-w-3xl rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-xl"
+              className="w-full max-w-3xl rounded-2xl border-2 border-[#2f4d9c] bg-slate-50 p-6 shadow-xl"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="mb-4 flex items-center justify-between">
-                <div className="text-3xl font-semibold text-slate-800">Contact Admin</div>
+              <div className="-mx-6 -mt-6 mb-4 flex items-center justify-between rounded-t-2xl bg-[#2f4d9c] px-6 py-4 text-white">
+                <div className="text-2xl font-semibold">Semester Distribution Reports</div>
                 <button
                   type="button"
-                  aria-label="Close"
-                  className="rounded p-1 text-slate-500 hover:bg-slate-200"
-                  onClick={() => setMessagePanelOpen(false)}
+                  aria-label="Close report inbox"
+                  className="rounded p-1 text-white/90 hover:bg-white/20"
+                  onClick={() => setHosReportInboxOpen(false)}
                 >
                   ✕
                 </button>
               </div>
-
-              <div className="mb-4 rounded-lg border border-slate-200 bg-white p-4">
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="text-sm font-semibold text-slate-700">Chat Record Date</div>
-                  <div className="relative">
+              {hosSemesterReports.length === 0 ? (
+                <div className="rounded-md border border-[#2f4d9c]/30 bg-white px-4 py-5 text-sm text-slate-700">
+                  No semester report generated yet.
+                </div>
+              ) : (
+                <>
+                  <div className="max-h-80 overflow-y-auto rounded-md border border-[#2f4d9c]/40 bg-white">
+                    {pagedHosReports.map((report) => (
+                      <div
+                        key={report.id}
+                        className="flex items-center justify-between gap-3 border-b border-[#2f4d9c]/10 px-4 py-3"
+                      >
+                        <div className="text-sm font-semibold text-slate-800">{report.title}</div>
+                        <button
+                          type="button"
+                          onClick={() => handleDownloadHosSemesterReport(report)}
+                          className="inline-flex items-center gap-2 rounded border border-[#2f4d9c]/40 bg-[#eef3ff] px-3 py-1 text-xs font-semibold text-[#2f4d9c] hover:bg-[#e0e9ff]"
+                        >
+                          ⬇ Download
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between px-1 text-sm">
                     <button
                       type="button"
-                      onClick={() => setCalendarOpen((v) => !v)}
-                      className="inline-flex items-center gap-2 rounded border border-slate-300 bg-white px-3 py-1 text-sm text-slate-800"
+                      onClick={() => setHosReportInboxPage((p) => Math.max(1, p - 1))}
+                      disabled={hosReportInboxPage <= 1}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                      {selectedChatDate}
-                      <span aria-hidden="true">📅</span>
+                      Previous
                     </button>
-                    {calendarOpen && (
-                      <div className="absolute z-20 mt-2 w-72 rounded-lg border border-slate-200 bg-white p-3 shadow-lg">
-                        <div className="mb-2 flex items-center justify-between">
-                          <button
-                            type="button"
-                            onClick={() => changeCalendarMonth(-1)}
-                            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
-                          >
-                            ‹
-                          </button>
-                          <div className="text-sm font-semibold text-slate-700">{calendarMonth}</div>
-                          <button
-                            type="button"
-                            onClick={() => changeCalendarMonth(1)}
-                            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
-                          >
-                            ›
-                          </button>
-                        </div>
-
-                        <div className="mb-1 grid grid-cols-7 gap-1 text-center text-xs font-semibold text-slate-500">
-                          {["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((d) => (
-                            <div key={d}>{d}</div>
-                          ))}
-                        </div>
-
-                        <div className="grid grid-cols-7 gap-1">
-                          {(() => {
-                            const [yearStr, monthStr] = calendarMonth.split("-");
-                            const year = Number(yearStr);
-                            const month = Number(monthStr) - 1;
-                            const firstDay = new Date(year, month, 1).getDay();
-                            const totalDays = new Date(year, month + 1, 0).getDate();
-                            const cells = [];
-
-                            for (let i = 0; i < firstDay; i += 1) {
-                              cells.push(<div key={`empty-${i}`} />);
-                            }
-
-                            for (let day = 1; day <= totalDays; day += 1) {
-                              const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(
-                                2,
-                                "0"
-                              )}`;
-                              const selectable = availableChatDates.has(dateKey);
-                              const isSelected = selectedChatDate === dateKey;
-
-                              cells.push(
-                                <button
-                                  key={dateKey}
-                                  type="button"
-                                  disabled={!selectable}
-                                  onClick={() => {
-                                    setSelectedChatDate(dateKey);
-                                    setCalendarOpen(false);
-                                  }}
-                                  className={`h-8 rounded text-xs ${
-                                    !selectable
-                                      ? "cursor-not-allowed bg-slate-100 text-slate-300"
-                                      : isSelected
-                                        ? "bg-[#2f4d9c] text-white"
-                                        : "text-slate-700 hover:bg-slate-100"
-                                  }`}
-                                >
-                                  {day}
-                                </button>
-                              );
-                            }
-
-                            return cells;
-                          })()}
-                        </div>
-                      </div>
-                    )}
+                    <span className="text-slate-600">
+                      Page {hosReportInboxPage} / {hosReportTotalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setHosReportInboxPage((p) => Math.min(hosReportTotalPages, p + 1))}
+                      disabled={hosReportInboxPage >= hosReportTotalPages}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Next
+                    </button>
                   </div>
-                </div>
-                <div className="max-h-72 space-y-2 overflow-y-auto pr-1 font-mono text-[15px] leading-6 text-slate-800">
-                  {visibleChatHistory.length > 0 ? (
-                    visibleChatHistory.map((entry, idx) => (
-                      <div key={idx}>
-                        <span className="text-slate-500">[{entry.time}]</span>{" "}
-                        <span className="font-semibold">{entry.sender}:</span> {entry.message}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="text-sm text-slate-500">No chat records for this date.</div>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-end gap-3">
-                <textarea
-                  value={chatInput}
-                  onChange={(e) => setChatInput(e.target.value)}
-                  placeholder="Write your message..."
-                  className="h-16 flex-1 resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-base text-slate-800 outline-none focus:border-[#2f4d9c]"
-                />
-                <button
-                  type="button"
-                  onClick={handleSendMessage}
-                  className="rounded-lg bg-[#2f4d9c] px-5 py-2 text-sm font-semibold text-white hover:bg-[#264183]"
-                >
-                  Send
-                </button>
-              </div>
+                </>
+              )}
             </div>
           </div>
         )}
@@ -1566,84 +1675,80 @@ export default function HeadofSchool() {
                 </div>
               )}
 
-              <div className="grid grid-cols-3 gap-6">
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Last name</div>
-                  <input
-                    value={searchLastNameInput}
-                    onChange={(e) => setSearchLastNameInput(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    className="rounded border border-slate-300 px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">First name</div>
-                  <input
-                    value={searchFirstNameInput}
-                    onChange={(e) => setSearchFirstNameInput(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    className="rounded border border-slate-300 px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Staff ID</div>
-                  <input
-                    value={searchEmployeeIdInput}
-                    onChange={(e) => setSearchEmployeeIdInput(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    className="rounded border border-slate-300 px-3 py-2 text-sm tabular-nums font-sans"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Title</div>
-                  <input
-                    value={searchTitleInput}
-                    onChange={(e) => setSearchTitleInput(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    className="rounded border border-slate-300 px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Department</div>
-                  <input
-                    value={searchDepartmentInput}
-                    onChange={(e) => setSearchDepartmentInput(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    className="rounded border border-slate-300 px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Year & Semester</div>
-                  <div className="flex items-center gap-2">
-                    <select
-                      value={searchYearInput}
-                      onChange={(e) => setSearchYearInput(e.target.value)}
+              <div className="rounded-md bg-[#f4f7ff] p-4">
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+                  <div className="flex flex-col gap-1">
+                    <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Name</div>
+                    <input
+                      value={searchNameInput}
+                      onChange={(e) => setSearchNameInput(e.target.value)}
                       onKeyDown={handleSearchKeyDown}
-                      onWheel={handleYearWheel}
-                      className="w-full rounded border border-slate-300 px-2 py-2 text-sm"
+                      placeholder="Last name, first name, or full name"
+                      className="rounded border border-slate-300 px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Staff ID</div>
+                    <input
+                      value={searchEmployeeIdInput}
+                      onChange={(e) => setSearchEmployeeIdInput(e.target.value)}
+                      onKeyDown={handleSearchKeyDown}
+                      className="rounded border border-slate-300 px-3 py-2 text-sm tabular-nums font-sans"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Department</div>
+                    <select
+                      value={searchDepartmentInput}
+                      onChange={(e) => setSearchDepartmentInput(e.target.value)}
+                      onKeyDown={handleSearchKeyDown}
+                      className="rounded border border-slate-300 px-3 py-2 text-sm"
                     >
-                      <option value="">Year</option>
-                      {yearOptions.map((year) => (
-                        <option key={year} value={year}>
-                          {year}
+                      <option value="">All departments</option>
+                      {WORKLOAD_SEARCH_DEPARTMENT_OPTIONS.map((dept) => (
+                        <option key={dept} value={dept}>
+                          {dept}
                         </option>
                       ))}
                     </select>
-                    <select
-                      value={searchSemesterInput}
-                      onChange={(e) => setSearchSemesterInput(e.target.value as "" | "S1" | "S2")}
-                      onKeyDown={handleSearchKeyDown}
-                      className="w-full rounded border border-slate-300 px-2 py-2 text-sm"
-                    >
-                      <option value="">Semester</option>
-                      <option value="S1">S1</option>
-                      <option value="S2">S2</option>
-                    </select>
                   </div>
                 </div>
-              </div>
-              <div className="mt-4 flex justify-center">
-                <SearchButton onClick={handleSearch} />
+                <div className="mt-4 grid grid-cols-1 items-end gap-6 md:grid-cols-3">
+                  <div className="flex flex-col gap-1">
+                    <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">Year & Semester</div>
+                    <div className="flex w-full min-w-0 items-center gap-2">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        list="hos-workload-year-options"
+                        value={searchYearInput}
+                        onChange={(e) => setSearchYearInput(e.target.value)}
+                        onKeyDown={handleSearchKeyDown}
+                        className="min-w-0 flex-1 rounded border border-slate-300 px-2 py-2 text-sm"
+                        placeholder="Year"
+                      />
+                      <datalist id="hos-workload-year-options">
+                        {yearOptions.map((year) => (
+                          <option key={year} value={year} />
+                        ))}
+                      </datalist>
+                      <select
+                        value={searchSemesterInput}
+                        onChange={(e) => setSearchSemesterInput(e.target.value as "" | "S1" | "S2")}
+                        onKeyDown={handleSearchKeyDown}
+                        className="min-w-0 flex-1 rounded border border-slate-300 px-2 py-2 text-sm"
+                      >
+                        <option value="">All semesters</option>
+                        <option value="S1">S1</option>
+                        <option value="S2">S2</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div className="flex items-end justify-center md:justify-self-center">
+                    <SearchButton onClick={handleSearch} />
+                  </div>
+                  <span className="hidden md:block" aria-hidden />
+                </div>
               </div>
 
               <div className="mt-6 text-lg font-semibold text-slate-700">Workload Report Sem 1 - 2025</div>
@@ -1735,8 +1840,8 @@ export default function HeadofSchool() {
                         <th className="w-14 px-2 py-2">Task</th>
                         <th className="px-3 py-2">NAME</th>
                         <th className="px-3 py-2">TITLE</th>
-                        <th className="px-3 py-2">DEPARTMENT / SCHOOL</th>
-                        <th className="px-3 py-2">REASONS</th>
+                        <th className="w-[180px] px-3 py-2">REASONS</th>
+                        <th className="px-3 py-2">DEPARTMENT</th>
                         <th className="px-3 py-2">STATUS</th>
                         <th className="px-3 py-2 text-center">TOTAL WORK HOURS</th>
                         <th className="px-3 py-2 text-right">SUBMITTED TIME</th>
@@ -1802,10 +1907,15 @@ export default function HeadofSchool() {
                                 <div className="text-xs text-slate-400">{item.studentId}</div>
                               </td>
                               <td className="px-3 py-3 text-slate-700">{item.title}</td>
-                              <td className="px-3 py-3 text-slate-700">{item.department || "-"}</td>
                               <td className="px-3 py-3 text-slate-600">
-                                {item.requestReason || extractRequestReason(item.description ?? "") || "- no reason provided -"}
+                                <div
+                                  className="max-w-[180px] truncate"
+                                  title={requestReasonText(item) || "No reason provided"}
+                                >
+                                  {requestReasonText(item) || "—"}
+                                </div>
                               </td>
+                              <td className="px-3 py-3 text-slate-600">{item.department || "—"}</td>
                               <td className="px-3 py-3">
                                 <StatusPill status={item.status} variant="supervisor" />
                               </td>
@@ -1834,7 +1944,7 @@ export default function HeadofSchool() {
               {detailsOpen && detailsItem && (
                 <div
                   className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-                  onClick={closeDetails}
+                  onClick={requestCloseDetails}
                 >
                   <div
                     className="w-full max-w-2xl rounded-sm bg-white p-0 shadow"
@@ -1842,15 +1952,19 @@ export default function HeadofSchool() {
                   >
                     <div className="rounded-sm border border-black">
                       <div className="flex items-center justify-between gap-4 border-b border-black/30 bg-white px-5 py-3">
-                        <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
-                          {detailsItem.studentId}-{detailsItem.semesterLabel}
-                          {detailsItem.periodLabel}
+                        <div className="flex items-center gap-3">
+                          <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
+                            {(() => {
+                              const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
+                              if (!matched) return `${detailsItem.periodLabel}-${detailsItem.department}`;
+                              return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}-${detailsItem.department}`;
+                            })()}
+                          </div>
                         </div>
                         <div className="flex items-center gap-3 text-sm font-semibold text-slate-800">
-                          <span className="text-base">{statusLabel(detailsItem.status)}</span>
                           <button
                             type="button"
-                            onClick={closeDetails}
+                            onClick={requestCloseDetails}
                             className="rounded bg-slate-200 px-3 py-1 text-xs font-bold text-slate-700 hover:bg-slate-300"
                           >
                             Close
@@ -1860,28 +1974,111 @@ export default function HeadofSchool() {
 
                       <form className="space-y-4 px-6 py-5" onSubmit={(e) => e.preventDefault()}>
                         <div className="grid grid-cols-2 gap-5">
-                          <InfoField label="Full name" value={detailsItem.name} />
-                          <InfoField label="Title" value={detailsItem.title} />
-                          <InfoField
-                            label="Total Work Hours"
-                            value={String(
-                              detailsBreakdown
-                                ? (["Teaching", "Assigned Roles", "HDR", "Service"] as BreakdownCategory[]).reduce(
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Name
+                            </div>
+                            <input readOnly value={detailsItem.name} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Staff ID
+                            </div>
+                            <input readOnly value={detailsItem.studentId} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Target teaching ratio
+                            </div>
+                            <input readOnly value="50.0%" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Actual teaching ratio
+                            </div>
+                            {(() => {
+                              const source = detailsBreakdown ?? breakdownById(detailsItem.id);
+                              const teaching = source.Teaching.reduce((sum, row) => sum + row.hours, 0);
+                              const total = (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
+                                (tabSum, tab) => tabSum + source[tab].reduce((sum, row) => sum + row.hours, 0),
+                                0
+                              );
+                              const ratio = total <= 0 ? "0.0%" : `${((teaching / total) * 100).toFixed(1)}%`;
+                              return (
+                                <input readOnly value={ratio} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base tabular-nums font-sans" />
+                              );
+                            })()}
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Total work hours
+                            </div>
+                            {(() => {
+                              const totalHours = detailsBreakdown
+                                ? (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
                                     (tabSum, tab) => tabSum + detailsBreakdown[tab].reduce((sum, row) => sum + row.hours, 0),
                                     0
                                   )
-                                : detailsItem.hours
-                            )}
-                            className="tabular-nums font-sans"
-                          />
-                          <InfoField label="Department" value={detailsItem.department} />
+                                : detailsItem.hours;
+                              return (
+                                <input readOnly value={totalHours} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base tabular-nums font-sans" />
+                              );
+                            })()}
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              Employment type
+                            </div>
+                            {(() => {
+                              const totalHours = detailsBreakdown
+                                ? (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
+                                    (tabSum, tab) => tabSum + detailsBreakdown[tab].reduce((sum, row) => sum + row.hours, 0),
+                                    0
+                                  )
+                                : detailsItem.hours;
+                              return (
+                                <input readOnly value={totalHours >= 800 ? "Full-time" : "Part-time"} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                              );
+                            })()}
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              New Staff
+                            </div>
+                            <input readOnly value="No" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                          </div>
+
+                          <div className="flex items-center gap-3">
+                            <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                              HoD Review
+                            </div>
+                            <input readOnly value="No" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                          </div>
                         </div>
 
                         <div>
-                          <div className="text-sm font-semibold uppercase text-slate-700">Workload Breakdown</div>
+                          <div className="flex items-center justify-between">
+                            <div className="text-sm font-semibold uppercase text-slate-700">Workload Breakdown</div>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setDetailsEditMode((v) => !v);
+                                setDetailsModalError("");
+                              }}
+                              className="rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white hover:bg-[#264183]"
+                            >
+                              {detailsEditMode ? "Done" : "Edit"}
+                            </button>
+                          </div>
                           <div className="mt-2 overflow-hidden rounded-sm border border-slate-300">
                             <div className="flex flex-wrap gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2">
-                              {(["Teaching", "Assigned Roles", "HDR", "Service"] as BreakdownCategory[]).map((tab) => (
+                              {(["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).map((tab) => (
                                 <button
                                   key={tab}
                                   type="button"
@@ -1901,31 +2098,75 @@ export default function HeadofSchool() {
                                 <tr className="text-left text-xs font-semibold uppercase text-slate-600">
                                   <th className="px-3 py-2">{detailsTab}</th>
                                   <th className="w-[120px] px-3 py-2 text-right">Hours</th>
+                                  {detailsEditMode ? <th className="w-[88px] px-3 py-2 text-center">Action</th> : null}
                                 </tr>
                               </thead>
                               <tbody className="divide-y divide-slate-200 bg-white text-sm text-slate-700">
                                 {(detailsBreakdown?.[detailsTab] ?? breakdownById(detailsItem.id)[detailsTab]).map((row, idx) => (
                                   <tr key={`${detailsItem.id}-${detailsTab}-${idx}`}>
                                     <td className="px-3 py-2">
-                                      <input
-                                        value={row.name}
-                                        onChange={(e) => updateBreakdownRow(detailsTab, idx, "name", e.target.value)}
-                                        maxLength={60}
-                                        className="w-[240px] max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-sm"
-                                      />
+                                      {detailsEditMode ? (
+                                        <input
+                                          value={row.name}
+                                          onChange={(e) => updateBreakdownRow(detailsTab, idx, "name", e.target.value)}
+                                          maxLength={60}
+                                          className="w-[240px] max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-sm"
+                                        />
+                                      ) : (
+                                        <span className="block px-1 py-1">{row.name}</span>
+                                      )}
                                     </td>
                                     <td className="px-3 py-2">
-                                      <input
-                                        type="text"
-                                        inputMode="decimal"
-                                        maxLength={8}
-                                        value={String(row.hours)}
-                                        onChange={(e) => updateBreakdownRow(detailsTab, idx, "hours", e.target.value)}
-                                        className="ml-auto w-24 rounded border border-slate-300 px-2 py-1 text-right tabular-nums font-sans text-sm"
-                                      />
+                                      {detailsEditMode ? (
+                                        <input
+                                          type="text"
+                                          inputMode="decimal"
+                                          maxLength={8}
+                                          value={String(row.hours)}
+                                          onChange={(e) => updateBreakdownRow(detailsTab, idx, "hours", e.target.value)}
+                                          className="ml-auto w-24 rounded border border-slate-300 px-2 py-1 text-right tabular-nums font-sans text-sm"
+                                        />
+                                      ) : (
+                                        <div className="text-right tabular-nums font-sans">{row.hours}</div>
+                                      )}
                                     </td>
+                                    {detailsEditMode ? (
+                                      <td className="px-3 py-2 text-center">
+                                        <button
+                                          type="button"
+                                          onClick={() => removeBreakdownRow(detailsTab, idx)}
+                                          className="rounded bg-slate-200 px-2 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-300 disabled:opacity-50"
+                                          disabled={(detailsBreakdown?.[detailsTab] ?? []).length <= 1}
+                                        >
+                                          Delete
+                                        </button>
+                                      </td>
+                                    ) : null}
                                   </tr>
                                 ))}
+                                {detailsEditMode ? (
+                                  <tr>
+                                    <td colSpan={3} className="px-3 py-2">
+                                      <button
+                                        type="button"
+                                        onClick={() => addBreakdownRow(detailsTab)}
+                                        className="rounded bg-[#2f4d9c] px-3 py-1 text-xs font-semibold text-white hover:bg-[#264183]"
+                                      >
+                                        + Add Row
+                                      </button>
+                                    </td>
+                                  </tr>
+                                ) : null}
+                                <tr className="bg-slate-50">
+                                  <td className="px-3 py-2 font-semibold">Total</td>
+                                  <td className="px-3 py-2 text-right font-semibold tabular-nums font-sans">
+                                    {(detailsBreakdown?.[detailsTab] ?? breakdownById(detailsItem.id)[detailsTab]).reduce(
+                                      (sum, row) => sum + row.hours,
+                                      0
+                                    )}
+                                  </td>
+                                  {detailsEditMode ? <td /> : null}
+                                </tr>
                               </tbody>
                             </table>
                           </div>
@@ -1937,7 +2178,7 @@ export default function HeadofSchool() {
                             onClick={() => setDescriptionExpanded((v) => !v)}
                             className="flex w-full items-center justify-between rounded-sm border border-slate-300 bg-slate-50 px-3 py-2 text-left text-sm font-semibold uppercase text-slate-700"
                           >
-                            <span>Note</span>
+                            <span>School of Operations notes</span>
                             <span className="text-base leading-none">{descriptionExpanded ? "−" : "+"}</span>
                           </button>
                           {descriptionExpanded && (
@@ -1953,10 +2194,13 @@ export default function HeadofSchool() {
                           <div className="text-sm font-semibold text-slate-700">Application Reason</div>
                           <textarea
                             readOnly
-                            value={detailsItem.requestReason || extractRequestReason(detailsItem.description ?? "") || "- no reason provided -"}
+                            value={requestReasonText(detailsItem) || "- no reason provided -"}
                             className="mt-2 h-24 w-full resize-none rounded-sm border border-slate-300 bg-white px-4 py-3 text-sm text-slate-700"
                           />
                         </div>
+                        {detailsModalError && (
+                          <div className="text-sm font-semibold text-[#dc2626]">{detailsModalError}</div>
+                        )}
 
                         {detailsItem.status === "pending" && (
                           <div className="flex items-center justify-center gap-24 pt-2">

--- a/frontend/src/pages/HeadofSchool.tsx
+++ b/frontend/src/pages/HeadofSchool.tsx
@@ -1953,18 +1953,12 @@ export default function HeadofSchool() {
                     <div className="rounded-sm border border-black">
                       <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
                         <div className="flex items-center gap-3">
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                          <div className="text-lg font-bold">
                             {(() => {
                               const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
-                              if (!matched) return detailsItem.periodLabel;
-                              return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}`;
+                              const period = matched ? `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}` : detailsItem.periodLabel;
+                              return `${period}-${detailsItem.department}-Academic`;
                             })()}
-                          </div>
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                            {detailsItem.department}
-                          </div>
-                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                            Academic
                           </div>
                         </div>
                         <button

--- a/frontend/src/pages/HeadofSchool.tsx
+++ b/frontend/src/pages/HeadofSchool.tsx
@@ -1951,25 +1951,29 @@ export default function HeadofSchool() {
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className="rounded-sm border border-black">
-                      <div className="flex items-center justify-between gap-4 border-b border-black/30 bg-white px-5 py-3">
+                      <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
                         <div className="flex items-center gap-3">
-                          <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
                             {(() => {
                               const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
-                              if (!matched) return `${detailsItem.periodLabel}-${detailsItem.department}`;
-                              return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}-${detailsItem.department}`;
+                              if (!matched) return detailsItem.periodLabel;
+                              return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}`;
                             })()}
                           </div>
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                            {detailsItem.department}
+                          </div>
+                          <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                            Academic
+                          </div>
                         </div>
-                        <div className="flex items-center gap-3 text-sm font-semibold text-slate-800">
-                          <button
-                            type="button"
-                            onClick={requestCloseDetails}
-                            className="rounded bg-slate-200 px-3 py-1 text-xs font-bold text-slate-700 hover:bg-slate-300"
-                          >
-                            Close
-                          </button>
-                        </div>
+                        <button
+                          type="button"
+                          onClick={requestCloseDetails}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-white/10 hover:bg-white/20"
+                        >
+                          <span className="text-xl leading-none">×</span>
+                        </button>
                       </div>
 
                       <form className="space-y-4 px-6 py-5" onSubmit={(e) => e.preventDefault()}>

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 import * as XLSX from "xlsx";
 import DashboardHeader from "../components/common/DashboardHeader";
-import { MOCK_DASHBOARD_USER } from "../data/mockDashboardUser";
 import LineMetricChartCard from "../components/common/LineMetricChartCard";
 import PaginationControls from "../components/common/PaginationControls";
 import ProfileModal from "../components/common/ProfileModal";
@@ -16,6 +15,7 @@ import WorkHoursBadge from "../components/common/WorkHoursBadge";
 
 type MockRequest = {
   id: number;
+  sourceWorkloadId?: number;
   studentId: string;
   semesterLabel: string;
   periodLabel: string;
@@ -29,17 +29,21 @@ type MockRequest = {
   rate: number;
   status: "pending" | "approved" | "rejected";
   hours: number;
+  detailSnapshot?: {
+    breakdown: BreakdownData;
+  };
   supervisorNote?: string;
   /** When true (from API), row is read-only and detail is blocked — superseded by a newer version. */
   cancelled?: boolean;
 };
 
-type BreakdownCategory = "Teaching" | "Assigned Roles" | "HDR" | "Service";
+type BreakdownCategory = "Teaching" | "Assigned Roles" | "HDR" | "Service" | "Research (residual)";
 type BreakdownEntry = { name: string; hours: number };
 type BreakdownData = Record<BreakdownCategory, BreakdownEntry[]>;
 
 const SUPERVISOR_DRAFT_KEY = "academic_to_supervisor_requests_v1";
 const SUPERVISOR_STATE_KEY = "supervisor_requests_state_v1";
+const OPS_ACADEMIC_DISTRIBUTED_KEY = "ops_academic_distributed_workloads_v1";
 const ACADEMIC_STATUS_SYNC_KEY = "academic_status_sync_v1";
 const ACADEMIC_NOTES_SYNC_KEY = "academic_notes_sync_v1";
 const SUPERVISOR_SYNC_EVENT = "supervisor-status-updated";
@@ -85,11 +89,20 @@ function readSupervisorState(): MockRequest[] {
 }
 
 function mergeDraftsIntoRequests(current: MockRequest[], drafts: MockRequest[]) {
-  if (!drafts.length) return current;
-  const existingIds = new Set(current.map((row) => row.id));
-  const incoming = drafts.filter((row) => !existingIds.has(row.id));
-  if (!incoming.length) return current;
-  return [...incoming, ...current];
+  const merged = [...drafts, ...current];
+  if (!merged.length) return merged;
+  const seen = new Set<string>();
+  const next: MockRequest[] = [];
+  for (const row of merged) {
+    const sourceId = Number(row.sourceWorkloadId);
+    const key = Number.isFinite(sourceId)
+      ? `src:${sourceId}`
+      : `legacy:${String(row.studentId).trim()}|${String(row.periodLabel).trim()}|${String(row.requestReason ?? "").trim()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    next.push(row);
+  }
+  return next;
 }
 
 function breakdownById(id: number, totalHours: number): BreakdownData {
@@ -130,6 +143,7 @@ function breakdownById(id: number, totalHours: number): BreakdownData {
       { name: studentB, hours: hdr2 },
     ],
     Service: [{ name: "Committee support", hours: service }],
+    "Research (residual)": [{ name: "Research (residual)", hours: 0 }],
   };
 }
 
@@ -214,7 +228,14 @@ export default function Supervisor() {
     date: string;
   };
 
-  const user = MOCK_DASHBOARD_USER;
+  const user = {
+    surname: "Rachel",
+    firstName: "Rachel",
+    employeeId: "12345931",
+    title: "Lecturer",
+    department: "Physics",
+    email: "rachel.rachel@uwa.edu.au",
+  };
 
   const [hasNewMessage, setHasNewMessage] = useState(true);
   const [messagePanelOpen, setMessagePanelOpen] = useState(false);
@@ -245,7 +266,7 @@ export default function Supervisor() {
   );
 
   const [loading] = useState(false);
-  const [pending, setPending] = useState<MockRequest[]>([]);
+  const [pending, setPending] = useState<MockRequest[]>(() => mergeDraftsIntoRequests(readSupervisorState(), []));
 
   useEffect(() => {
     function mergeLatestDrafts() {
@@ -262,6 +283,8 @@ export default function Supervisor() {
       mergeLatestDrafts();
     }
 
+    // Sync existing Academic submissions when HoD page is opened after submit.
+    mergeLatestDrafts();
     window.addEventListener("storage", onStorage);
     window.addEventListener(ACADEMIC_DRAFT_EVENT, onDraftEvent as EventListener);
     return () => {
@@ -279,9 +302,30 @@ export default function Supervisor() {
     if (typeof window === "undefined") return;
     const sync: Record<string, "pending" | "approved" | "rejected"> = {};
     const notesSync: Record<string, string> = {};
+    let latestDistributedIdByStaffId: Record<string, number> = {};
+    try {
+      const raw = window.localStorage.getItem(OPS_ACADEMIC_DISTRIBUTED_KEY);
+      const parsed = raw ? (JSON.parse(raw) as MockRequest[]) : [];
+      if (Array.isArray(parsed)) {
+        parsed.forEach((row) => {
+          const sid = String(row.studentId ?? "").trim();
+          const id = Number(row.id);
+          if (!sid || !Number.isFinite(id)) return;
+          if (row.cancelled || row.status !== "approved") return;
+          latestDistributedIdByStaffId[sid] = id;
+        });
+      }
+    } catch {
+      latestDistributedIdByStaffId = {};
+    }
     pending.forEach((row) => {
-      if (row.studentId) sync[row.studentId] = row.status;
-      if (row.studentId && row.supervisorNote) notesSync[row.studentId] = row.supervisorNote;
+      const sourceId = Number(row.sourceWorkloadId);
+      const fallbackId = latestDistributedIdByStaffId[String(row.studentId ?? "").trim()];
+      const effectiveSourceId = Number.isFinite(sourceId) ? sourceId : fallbackId;
+      if (Number.isFinite(effectiveSourceId)) sync[String(effectiveSourceId)] = row.status;
+      if (Number.isFinite(effectiveSourceId) && row.supervisorNote) {
+        notesSync[String(effectiveSourceId)] = row.supervisorNote;
+      }
     });
     window.localStorage.setItem(ACADEMIC_STATUS_SYNC_KEY, JSON.stringify(sync));
     window.localStorage.setItem(ACADEMIC_NOTES_SYNC_KEY, JSON.stringify(notesSync));
@@ -313,6 +357,7 @@ export default function Supervisor() {
   const [detailsItem, setDetailsItem] = useState<MockRequest | null>(null);
   const [detailsBreakdown, setDetailsBreakdown] = useState<BreakdownData | null>(null);
   const [detailsTab, setDetailsTab] = useState<BreakdownCategory>("Teaching");
+  const [detailsEditMode, setDetailsEditMode] = useState(false);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [noteModalOpen, setNoteModalOpen] = useState(false);
   const [noteDraft, setNoteDraft] = useState("");
@@ -322,16 +367,12 @@ export default function Supervisor() {
   const [noteTargetId, setNoteTargetId] = useState<number | null>(null);
 
   const [searchEmployeeIdInput, setSearchEmployeeIdInput] = useState("");
-  const [searchLastNameInput, setSearchLastNameInput] = useState("");
-  const [searchFirstNameInput, setSearchFirstNameInput] = useState("");
-  const [searchTitleInput, setSearchTitleInput] = useState("");
+  const [searchNameInput, setSearchNameInput] = useState("");
   const [searchYearInput, setSearchYearInput] = useState("");
   const [searchSemesterInput, setSearchSemesterInput] = useState<"" | "S1" | "S2">("");
   const [searchFilters, setSearchFilters] = useState({
     employeeId: "",
-    lastName: "",
-    firstName: "",
-    title: "",
+    name: "",
     year: "",
     semester: "",
   });
@@ -354,11 +395,6 @@ export default function Supervisor() {
   const [exportYearToInput, setExportYearToInput] = useState("");
   const [exportSemesterInput, setExportSemesterInput] = useState<"All" | "S1" | "S2">("All");
   const [exportMessage, setExportMessage] = useState("");
-  const selectedYear = Number(searchYearInput) || currentYear;
-  const yearOptions = useMemo(
-    () => Array.from({ length: 11 }, (_, i) => String(selectedYear - 5 + i)),
-    [selectedYear]
-  );
 
   const pendingCount = useMemo(
     () => pending.filter((it) => it.status === "pending").length,
@@ -387,16 +423,13 @@ export default function Supervisor() {
         return false;
       }
 
-      if (searchFilters.firstName && !firstName.includes(searchFilters.firstName)) {
-        return false;
-      }
-
-      if (searchFilters.lastName && !lastName.includes(searchFilters.lastName)) {
-        return false;
-      }
-
-      if (searchFilters.title && !it.title.toLowerCase().includes(searchFilters.title)) {
-        return false;
+      if (searchFilters.name) {
+        const q = searchFilters.name;
+        const matchByFull = fullName.includes(q);
+        const matchByFirst = firstName.includes(q);
+        const matchByLast = lastName.includes(q);
+        const matchByReversed = `${lastName} ${firstName}`.includes(q);
+        if (!(matchByFull || matchByFirst || matchByLast || matchByReversed)) return false;
       }
 
       const submittedText = submittedTimeById(it.id);
@@ -697,9 +730,7 @@ export default function Supervisor() {
   function handleSearch() {
     setSearchFilters({
       employeeId: searchEmployeeIdInput.trim().toLowerCase(),
-      lastName: searchLastNameInput.trim().toLowerCase(),
-      firstName: searchFirstNameInput.trim().toLowerCase(),
-      title: searchTitleInput.trim().toLowerCase(),
+      name: searchNameInput.trim().toLowerCase(),
       year: searchYearInput.trim().toLowerCase(),
       semester: searchSemesterInput.trim().toLowerCase(),
     });
@@ -716,14 +747,15 @@ export default function Supervisor() {
       return;
     }
     setDetailsItem(item);
-    setDetailsBreakdown(breakdownById(item.id, item.hours));
+    setDetailsBreakdown(item.detailSnapshot?.breakdown ?? breakdownById(item.id, item.hours));
     setDetailsOpen(true);
+    setDetailsEditMode(false);
     setDescriptionExpanded(false);
     setDetailsModalError("");
   }
 
   function requestCloseDetails() {
-    if (detailsBreakdown) {
+    if (detailsEditMode && detailsBreakdown) {
       const hasEmptyRow = (Object.keys(detailsBreakdown) as BreakdownCategory[]).some((tab) =>
         detailsBreakdown[tab].some((row) => row.name.trim() === "")
       );
@@ -739,6 +771,7 @@ export default function Supervisor() {
     setDetailsOpen(false);
     setDetailsItem(null);
     setDetailsBreakdown(null);
+    setDetailsEditMode(false);
     setDetailsModalError("");
     setNoteModalOpen(false);
     setNoteDraft("");
@@ -783,13 +816,6 @@ export default function Supervisor() {
         [tab]: currentRows.filter((_, rowIdx) => rowIdx !== idx),
       };
     });
-  }
-
-  function handleYearWheel(event: React.WheelEvent<HTMLSelectElement>) {
-    event.preventDefault();
-    const delta = event.deltaY > 0 ? 1 : -1;
-    const nextYear = (Number(searchYearInput) || currentYear) + delta;
-    setSearchYearInput(String(nextYear));
   }
 
   function handleSearchKeyDown(event: React.KeyboardEvent<HTMLInputElement | HTMLSelectElement>) {
@@ -1068,26 +1094,17 @@ export default function Supervisor() {
           {activeSection === "approval" && (
             <section>
           {/* Search Fields */}
-          <div className="grid grid-cols-3 gap-6">
+          <div className="flex items-end gap-4">
+            <div className="grid flex-1 grid-cols-3 gap-4">
             <div className="flex flex-col gap-1">
               <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">
-                Last name
-              </div>
-          <input
-                value={searchLastNameInput}
-                onChange={(e) => setSearchLastNameInput(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-                className="rounded border border-slate-300 px-3 py-2 text-sm"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">
-                First name
+                Name
               </div>
               <input
-                value={searchFirstNameInput}
-                onChange={(e) => setSearchFirstNameInput(e.target.value)}
+                value={searchNameInput}
+                onChange={(e) => setSearchNameInput(e.target.value)}
                 onKeyDown={handleSearchKeyDown}
+                placeholder="First, last, or full name"
                 className="rounded border border-slate-300 px-3 py-2 text-sm"
               />
             </div>
@@ -1104,39 +1121,23 @@ export default function Supervisor() {
             </div>
             <div className="flex flex-col gap-1">
               <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">
-                Title
-              </div>
-              <input
-                value={searchTitleInput}
-                onChange={(e) => setSearchTitleInput(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-                className="rounded border border-slate-300 px-3 py-2 text-sm"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <div className="w-fit rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white">
                 Year & Semester
               </div>
               <div className="flex items-center gap-2">
-                <select
+                <input
                   value={searchYearInput}
                   onChange={(e) => setSearchYearInput(e.target.value)}
                   onKeyDown={handleSearchKeyDown}
-                  onWheel={handleYearWheel}
-                  className="w-full rounded border border-slate-300 px-2 py-2 text-sm"
-                >
-                  <option value="">Year</option>
-                  {yearOptions.map((year) => (
-                    <option key={year} value={year}>
-                      {year}
-                    </option>
-                  ))}
-                </select>
+                  placeholder="Year"
+                  maxLength={4}
+                  inputMode="numeric"
+                  className="w-1/2 min-w-[88px] rounded border border-slate-300 px-2 py-2 text-sm"
+                />
                 <select
                   value={searchSemesterInput}
                   onChange={(e) => setSearchSemesterInput(e.target.value as "" | "S1" | "S2")}
                   onKeyDown={handleSearchKeyDown}
-                  className="w-full rounded border border-slate-300 px-2 py-2 text-sm"
+                  className="w-1/2 min-w-[104px] rounded border border-slate-300 px-2 py-2 text-sm"
                 >
                   <option value="">Semester</option>
                   <option value="S1">S1</option>
@@ -1144,7 +1145,8 @@ export default function Supervisor() {
                 </select>
               </div>
             </div>
-            <div className="flex items-end justify-start">
+            </div>
+            <div className="pb-[1px]">
               <SearchButton onClick={handleSearch} />
             </div>
           </div>
@@ -1250,7 +1252,7 @@ export default function Supervisor() {
                     <th className="w-14 px-2 py-2">Task</th>
                     <th className="px-3 py-2">NAME</th>
                     <th className="px-3 py-2">TITLE</th>
-                    <th className="px-3 py-2">REASONS</th>
+                    <th className="px-3 py-2">DEPARTMENT</th>
                     <th className="px-3 py-2">STATUS</th>
                     <th className="px-3 py-2 text-center">TOTAL WORK HOURS</th>
                     <th className="px-3 py-2 text-right">SUBMITTED TIME</th>
@@ -1323,11 +1325,7 @@ export default function Supervisor() {
                             <div className="text-xs text-slate-400">{item.studentId}</div>
                           </td>
                           <td className="px-3 py-3 text-slate-700">{item.title}</td>
-                          <td className="px-3 py-3 text-slate-600">
-                            {item.requestReason ||
-                              extractRequestReason(item.description ?? "") ||
-                              "- no reason provided -"}
-                          </td>
+                          <td className="px-3 py-3 text-slate-600">{item.department || "—"}</td>
                           <td className="px-3 py-3">
                             <StatusPill status={item.status} variant="supervisor" />
                           </td>
@@ -1368,19 +1366,11 @@ export default function Supervisor() {
                     {/* Header */}
                     <div className="flex items-center justify-between gap-4 border-b border-black/30 bg-white px-5 py-3">
                       <div className="flex items-center gap-3">
-                        {/* Student identifier block */}
                         <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
-                          {detailsItem.studentId}-{detailsItem.semesterLabel}
-                          {detailsItem.periodLabel}
+                          2025-S1-Physics
                         </div>
                       </div>
                       <div className="flex items-center gap-3 text-sm font-semibold text-slate-800">
-                        <div className="flex items-center gap-2">
-                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white ring-1 ring-black">
-                            ☁
-                          </div>
-                          <span className="text-base">{statusLabel(detailsItem.status)}</span>
-                        </div>
                         <button
                           type="button"
                           onClick={requestCloseDetails}
@@ -1399,67 +1389,109 @@ export default function Supervisor() {
                       <div className="grid grid-cols-2 gap-5">
                         <div className="flex items-center gap-3">
                           <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
-                            Full name
+                            Name
                           </div>
-          <input
-                            readOnly
-                            value={detailsItem.name}
-                            className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base"
-                          />
+                          <input readOnly value={detailsItem.name} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
                         </div>
 
                         <div className="flex items-center gap-3">
                           <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
-                            Title
+                            Staff ID
                           </div>
-          <input
-                            readOnly
-                            value={detailsItem.title}
-                            className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base"
-                          />
+                          <input readOnly value={detailsItem.studentId} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
                         </div>
 
                         <div className="flex items-center gap-3">
                           <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
-                            Total Work Hours
+                            Target teaching ratio
+                          </div>
+                          <input readOnly value="50.0%" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                          <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                            Actual teaching ratio
                           </div>
                           {(() => {
-                            const totalHours =
-                              detailsBreakdown
-                                ? (["Teaching", "Assigned Roles", "HDR", "Service"] as BreakdownCategory[]).reduce(
-                                    (tabSum, tab) =>
-                                      tabSum + detailsBreakdown[tab].reduce((sum, row) => sum + row.hours, 0),
-                                    0
-                                  )
-                                : detailsItem.hours;
+                            const source = detailsBreakdown ?? breakdownById(detailsItem.id, detailsItem.hours);
+                            const teaching = source.Teaching.reduce((sum, row) => sum + row.hours, 0);
+                            const total = (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
+                              (tabSum, tab) => tabSum + source[tab].reduce((sum, row) => sum + row.hours, 0),
+                              0
+                            );
+                            const ratio = total <= 0 ? "0.0%" : `${((teaching / total) * 100).toFixed(1)}%`;
                             return (
-          <input
-                            readOnly
-                            value={totalHours}
-                            className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base tabular-nums font-sans"
-                          />
+                              <input readOnly value={ratio} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base tabular-nums font-sans" />
                             );
                           })()}
                         </div>
 
                         <div className="flex items-center gap-3">
                           <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
-                            Department
+                            Total work hours
                           </div>
-          <input
-                            readOnly
-                            value={detailsItem.department}
-                            className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base"
-                          />
+                          {(() => {
+                            const totalHours = detailsBreakdown
+                              ? (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
+                                  (tabSum, tab) => tabSum + detailsBreakdown[tab].reduce((sum, row) => sum + row.hours, 0),
+                                  0
+                                )
+                              : detailsItem.hours;
+                            return (
+                              <input readOnly value={totalHours} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base tabular-nums font-sans" />
+                            );
+                          })()}
                         </div>
 
+                        <div className="flex items-center gap-3">
+                          <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                            Employment type
+                          </div>
+                          {(() => {
+                            const totalHours = detailsBreakdown
+                              ? (["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).reduce(
+                                  (tabSum, tab) => tabSum + detailsBreakdown[tab].reduce((sum, row) => sum + row.hours, 0),
+                                  0
+                                )
+                              : detailsItem.hours;
+                            return (
+                              <input readOnly value={totalHours >= 800 ? "Full-time" : "Part-time"} className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                            );
+                          })()}
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                          <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                            New Staff
+                          </div>
+                          <input readOnly value="No" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                          <div className="w-32 rounded-sm bg-[#2f4d9c] px-3 py-2 text-center text-base font-semibold text-white">
+                            HoD Review
+                          </div>
+                          <input readOnly value="No" className="w-full flex-1 rounded-sm border border-[#2f4d9c] px-3 py-2 text-base" />
+                        </div>
                       </div>
 
                       <div>
-                        <div className="text-sm font-semibold uppercase text-slate-700">Workload Breakdown</div>
+                        <div className="flex items-center justify-between">
+                          <div className="text-sm font-semibold uppercase text-slate-700">Workload Breakdown</div>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDetailsEditMode((v) => !v);
+                              setDetailsModalError("");
+                            }}
+                            className="rounded bg-[#2f4d9c] px-3 py-1 text-xs font-bold text-white hover:bg-[#264183]"
+                          >
+                            {detailsEditMode ? "Done" : "Edit"}
+                          </button>
+                        </div>
                         <div className="mt-2 overflow-hidden rounded-sm border border-slate-300">
                           <div className="flex flex-wrap gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2">
-                            {(["Teaching", "Assigned Roles", "HDR", "Service"] as BreakdownCategory[]).map((tab) => (
+                            {(["Teaching", "Assigned Roles", "HDR", "Service", "Research (residual)"] as BreakdownCategory[]).map((tab) => (
                               <button
                                 key={tab}
                                 type="button"
@@ -1479,53 +1511,65 @@ export default function Supervisor() {
                               <tr className="text-left text-xs font-semibold uppercase text-slate-600">
                                 <th className="px-3 py-2">{detailsTab}</th>
                                 <th className="w-[120px] px-3 py-2 text-right">Hours</th>
-                                <th className="w-[88px] px-3 py-2 text-center">Action</th>
+                                {detailsEditMode ? <th className="w-[88px] px-3 py-2 text-center">Action</th> : null}
                               </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-200 bg-white text-sm text-slate-700">
                               {(detailsBreakdown?.[detailsTab] ?? breakdownById(detailsItem.id, detailsItem.hours)[detailsTab]).map((row, idx) => (
                                 <tr key={`${detailsItem.id}-${detailsTab}-${idx}`}>
                                   <td className="px-3 py-2">
-          <input
-                                      value={row.name}
-                                      onChange={(e) => updateBreakdownRow(detailsTab, idx, "name", e.target.value)}
-                                      maxLength={60}
-                                      className="w-[240px] max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-sm"
-                                    />
+                                    {detailsEditMode ? (
+                                      <input
+                                        value={row.name}
+                                        onChange={(e) => updateBreakdownRow(detailsTab, idx, "name", e.target.value)}
+                                        maxLength={60}
+                                        className="w-[240px] max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-sm"
+                                      />
+                                    ) : (
+                                      <span className="block px-1 py-1">{row.name}</span>
+                                    )}
                                   </td>
                                   <td className="px-3 py-2">
-                                    <input
-                                      type="text"
-                                      inputMode="decimal"
-                                      maxLength={8}
-                                      value={String(row.hours)}
-                                      onChange={(e) => updateBreakdownRow(detailsTab, idx, "hours", e.target.value)}
-                                      className="ml-auto w-24 rounded border border-slate-300 px-2 py-1 text-right tabular-nums font-sans text-sm"
-                                    />
+                                    {detailsEditMode ? (
+                                      <input
+                                        type="text"
+                                        inputMode="decimal"
+                                        maxLength={8}
+                                        value={String(row.hours)}
+                                        onChange={(e) => updateBreakdownRow(detailsTab, idx, "hours", e.target.value)}
+                                        className="ml-auto w-24 rounded border border-slate-300 px-2 py-1 text-right tabular-nums font-sans text-sm"
+                                      />
+                                    ) : (
+                                      <div className="text-right tabular-nums font-sans">{row.hours}</div>
+                                    )}
                                   </td>
-                                  <td className="px-3 py-2 text-center">
+                                  {detailsEditMode ? (
+                                    <td className="px-3 py-2 text-center">
+                                      <button
+                                        type="button"
+                                        onClick={() => removeBreakdownRow(detailsTab, idx)}
+                                        className="rounded bg-slate-200 px-2 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-300 disabled:opacity-50"
+                                        disabled={(detailsBreakdown?.[detailsTab] ?? []).length <= 1}
+                                      >
+                                        Delete
+                                      </button>
+                                    </td>
+                                  ) : null}
+                                </tr>
+                              ))}
+                              {detailsEditMode ? (
+                                <tr>
+                                  <td colSpan={3} className="px-3 py-2">
                                     <button
                                       type="button"
-                                      onClick={() => removeBreakdownRow(detailsTab, idx)}
-                                      className="rounded bg-slate-200 px-2 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-300 disabled:opacity-50"
-                                      disabled={(detailsBreakdown?.[detailsTab] ?? []).length <= 1}
+                                      onClick={() => addBreakdownRow(detailsTab)}
+                                      className="rounded bg-[#2f4d9c] px-3 py-1 text-xs font-semibold text-white hover:bg-[#264183]"
                                     >
-                                      Delete
+                                      + Add Row
                                     </button>
                                   </td>
                                 </tr>
-                              ))}
-                              <tr>
-                                <td colSpan={3} className="px-3 py-2">
-                                  <button
-                                    type="button"
-                                    onClick={() => addBreakdownRow(detailsTab)}
-                                    className="rounded bg-[#2f4d9c] px-3 py-1 text-xs font-semibold text-white hover:bg-[#264183]"
-                                  >
-                                    + Add Row
-                                  </button>
-                                </td>
-                              </tr>
+                              ) : null}
                               <tr className="bg-slate-50">
                                 <td className="px-3 py-2 font-semibold">Total</td>
                                 <td className="px-3 py-2 text-right font-semibold tabular-nums font-sans">
@@ -1534,7 +1578,7 @@ export default function Supervisor() {
                                     0
                                   )}
                                 </td>
-                                <td />
+                                {detailsEditMode ? <td /> : null}
                               </tr>
                             </tbody>
                           </table>
@@ -1547,7 +1591,7 @@ export default function Supervisor() {
                           onClick={() => setDescriptionExpanded((v) => !v)}
                           className="flex w-full items-center justify-between rounded-sm border border-slate-300 bg-slate-50 px-3 py-2 text-left text-sm font-semibold uppercase text-slate-700"
                         >
-                          <span>Note</span>
+                          <span>School of Operations notes</span>
                           <span className="text-base leading-none">{descriptionExpanded ? "−" : "+"}</span>
                         </button>
                         {descriptionExpanded && (

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -48,11 +48,45 @@ const ACADEMIC_STATUS_SYNC_KEY = "academic_status_sync_v1";
 const ACADEMIC_NOTES_SYNC_KEY = "academic_notes_sync_v1";
 const SUPERVISOR_SYNC_EVENT = "supervisor-status-updated";
 const ACADEMIC_DRAFT_EVENT = "academic-drafts-updated";
+const HOD_ANNUAL_REPORTS_KEY = "hod_annual_report_inbox_v1";
+
+type HodAnnualReportItem = {
+  id: string;
+  year: number;
+  department: string;
+  title: string;
+  createdAt: string;
+  readAt?: string;
+  isDemo?: boolean;
+  rows: Record<string, string | number>[];
+};
+
+function readHodAnnualReports(): HodAnnualReportItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(HOD_ANNUAL_REPORTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as HodAnnualReportItem[];
+  } catch {
+    return [];
+  }
+}
+
+function writeHodAnnualReports(items: HodAnnualReportItem[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(HOD_ANNUAL_REPORTS_KEY, JSON.stringify(items));
+}
 
 function submittedTimeById(id: number) {
   const day = ((id - 1) % 28) + 1;
   const hour = 8 + (id % 9);
   return `2026-03-${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:00`;
+}
+
+function displayNameWithoutComma(raw: string) {
+  return raw.replace(/,/g, " ").replace(/\s+/g, " ").trim();
 }
 
 function readAcademicDrafts(): MockRequest[] {
@@ -167,6 +201,14 @@ function workloadModalNotes(row: Pick<MockRequest, "notes" | "description">) {
   return cleanDescription(row.description ?? "");
 }
 
+function requestReasonText(row: Pick<MockRequest, "requestReason" | "description">) {
+  return row.requestReason?.trim() || extractRequestReason(row.description ?? "").trim();
+}
+
+function reportStatusText(status: MockRequest["status"]) {
+  return status === "approved" ? "Approved" : status === "rejected" ? "Rejected" : "Pending";
+}
+
 function parsePeriod(periodLabel: string) {
   const matched = periodLabel.match(/(\d{4})-(1|2)/);
   if (!matched) return { year: NaN, semester: "" as "" | "S1" | "S2" };
@@ -220,14 +262,58 @@ function reseedSemestersIfNeeded(items: MockRequest[]) {
   });
 }
 
-export default function Supervisor() {
-  type ChatMessage = {
-    sender: "Sam" | "Admin";
-    message: string;
-    time: string;
-    date: string;
-  };
+function annualReportAvailableOn(year: number) {
+  return new Date(year + 1, 0, 1, 0, 0, 0, 0);
+}
 
+function buildHodAnnualReportRows(rows: MockRequest[], department: string) {
+  return rows
+    .filter((row) => !row.cancelled && row.department === department)
+    .sort((a, b) => a.periodLabel.localeCompare(b.periodLabel) || a.name.localeCompare(b.name))
+    .map((row) => {
+      const parsed = parsePeriod(row.periodLabel);
+      return {
+        "Staff ID": row.studentId,
+        Name: displayNameWithoutComma(row.name),
+        Department: row.department,
+        Title: row.title,
+        Semester: parsed.semester || row.semesterLabel || row.periodLabel,
+        Status: reportStatusText(row.status),
+        "Total Work Hours": row.hours,
+        "Submitted Time": submittedTimeById(row.id),
+        "Application Reason": requestReasonText(row) || "—",
+        "HoD Review Note": row.supervisorNote?.trim() || "—",
+      };
+    });
+}
+
+function createHodAnnualDemoReport(department: string): HodAnnualReportItem {
+  return {
+    id: `hod-report-demo-2025-${department.replace(/\s+/g, "-").toLowerCase()}`,
+    year: 2025,
+    department,
+    title: `2025 ${department} annual report generated`,
+    createdAt: "2026-01-01T09:00:00.000Z",
+    readAt: undefined,
+    isDemo: true,
+    rows: [
+      {
+        "Staff ID": "12345931",
+        Name: "Dias John",
+        Department: department,
+        Title: "Lecturer",
+        Semester: "S1",
+        Status: "Pending",
+        "Total Work Hours": 793.5,
+        "Submitted Time": "2025-11-28 09:30",
+        "Application Reason": "wrong",
+        "HoD Review Note": "—",
+      },
+    ],
+  };
+}
+
+export default function Supervisor() {
   const user = {
     surname: "Rachel",
     firstName: "Rachel",
@@ -237,24 +323,11 @@ export default function Supervisor() {
     email: "rachel.rachel@uwa.edu.au",
   };
 
-  const [hasNewMessage, setHasNewMessage] = useState(true);
-  const [messagePanelOpen, setMessagePanelOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   const [avatarSrc, setAvatarSrc] = useState<string | null>(null);
-  const [chatInput, setChatInput] = useState("");
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([
-    { sender: "Sam", message: "I have a question about workload item #11.", time: "09:10", date: "2026-04-22" },
-    { sender: "Admin", message: "Please check the teaching hours again.", time: "09:16", date: "2026-04-22" },
-    { sender: "Sam", message: "Thank you, I will update it.", time: "09:18", date: "2026-04-23" },
-  ]);
-  const [selectedChatDate, setSelectedChatDate] = useState("2026-04-23");
-  const [calendarOpen, setCalendarOpen] = useState(false);
-  const [calendarMonth, setCalendarMonth] = useState("2026-04");
-  const availableChatDates = useMemo(() => new Set(chatHistory.map((entry) => entry.date)), [chatHistory]);
-  const visibleChatHistory = useMemo(
-    () => chatHistory.filter((entry) => entry.date === selectedChatDate),
-    [chatHistory, selectedChatDate]
-  );
+  const [hodReportInboxOpen, setHodReportInboxOpen] = useState(false);
+  const [hodAnnualReports, setHodAnnualReports] = useState<HodAnnualReportItem[]>(() => readHodAnnualReports());
+  const [hodReportInboxPage, setHodReportInboxPage] = useState(1);
   const currentYear = useMemo(() => new Date().getFullYear(), []);
   const currentSemester = useMemo<"S1" | "S2">(() => {
     const month = new Date().getMonth() + 1;
@@ -395,11 +468,110 @@ export default function Supervisor() {
   const [exportYearToInput, setExportYearToInput] = useState("");
   const [exportSemesterInput, setExportSemesterInput] = useState<"All" | "S1" | "S2">("All");
   const [exportMessage, setExportMessage] = useState("");
+  const hodReportsPerPage = 10;
+  const hodUnreadReportCount = useMemo(
+    () => hodAnnualReports.filter((item) => !item.readAt).length,
+    [hodAnnualReports]
+  );
+  const hodReportTotalPages = Math.max(1, Math.ceil(hodAnnualReports.length / hodReportsPerPage));
+  const pagedHodAnnualReports = useMemo(() => {
+    const start = (hodReportInboxPage - 1) * hodReportsPerPage;
+    return hodAnnualReports.slice(start, start + hodReportsPerPage);
+  }, [hodAnnualReports, hodReportInboxPage]);
+
+  function handleDownloadHodAnnualReport(report: HodAnnualReportItem) {
+    if (!report.rows.length) return;
+    const ws = XLSX.utils.json_to_sheet(report.rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, `${report.year}`);
+    XLSX.writeFile(
+      wb,
+      `hod_${report.department.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}_annual_report_${report.year}.xlsx`
+    );
+  }
 
   const pendingCount = useMemo(
     () => pending.filter((it) => it.status === "pending").length,
     [pending]
   );
+
+  useEffect(() => {
+    setHodAnnualReports((prev) => {
+      const base = (prev.length ? prev : readHodAnnualReports()).map((item) => ({
+        ...item,
+        title: `${item.year} ${item.department} annual report generated`,
+      }));
+      if (base.length) {
+        writeHodAnnualReports(base);
+        return base;
+      }
+      const seeded = [createHodAnnualDemoReport(user.department)];
+      writeHodAnnualReports(seeded);
+      return seeded;
+    });
+  }, [user.department]);
+
+  useEffect(() => {
+    const now = new Date();
+    const existing = readHodAnnualReports();
+    const existingByKey = new Map<string, HodAnnualReportItem>(
+      existing.map((item) => [`${item.year}-${item.department}`, item] as const)
+    );
+    const availableYears = new Set<number>();
+
+    pending.forEach((row) => {
+      if (row.cancelled || row.department !== user.department) return;
+      const parsed = parsePeriod(row.periodLabel);
+      if (!Number.isFinite(parsed.year)) return;
+      if (now < annualReportAvailableOn(parsed.year)) return;
+      availableYears.add(parsed.year);
+    });
+
+    const newReports: HodAnnualReportItem[] = [];
+    const replacedDemoKeys = new Set<string>();
+    availableYears.forEach((year) => {
+      const key = `${year}-${user.department}`;
+      const existingItem = existingByKey.get(key);
+      if (existingItem && !existingItem.isDemo) return;
+      const yearRows = buildHodAnnualReportRows(
+        pending.filter((row) => parsePeriod(row.periodLabel).year === year),
+        user.department
+      );
+      if (!yearRows.length) return;
+      if (existingItem?.isDemo) replacedDemoKeys.add(key);
+      newReports.push({
+        id: `hod-report-${year}-${user.department.replace(/\s+/g, "-").toLowerCase()}-${Date.now()}`,
+        year,
+        department: user.department,
+        title: `${year} ${user.department} annual report generated`,
+        createdAt: new Date().toISOString(),
+        rows: yearRows,
+      });
+    });
+
+    if (!newReports.length) return;
+    const retainedExisting = existing.filter((item) => !replacedDemoKeys.has(`${item.year}-${item.department}`));
+    const next = [...newReports, ...retainedExisting].sort(
+      (a, b) => Date.parse(b.createdAt || "") - Date.parse(a.createdAt || "")
+    );
+    writeHodAnnualReports(next);
+    setHodAnnualReports(next);
+  }, [pending, user.department]);
+
+  useEffect(() => {
+    if (!hodReportInboxOpen) return;
+    setHodAnnualReports((prev) => {
+      const now = new Date().toISOString();
+      const next = prev.map((item) => (item.readAt ? item : { ...item, readAt: now }));
+      writeHodAnnualReports(next);
+      return next;
+    });
+  }, [hodReportInboxOpen]);
+
+  useEffect(() => {
+    const total = Math.max(1, Math.ceil(hodAnnualReports.length / hodReportsPerPage));
+    setHodReportInboxPage((prev) => Math.min(Math.max(1, prev), total));
+  }, [hodAnnualReports.length]);
 
   const itemsForFilter = useMemo(() => {
     const byStatus =
@@ -825,27 +997,6 @@ export default function Supervisor() {
     }
   }
 
-  function openMessagePanel() {
-    setMessagePanelOpen(true);
-    setHasNewMessage(false);
-  }
-
-  function handleSendMessage() {
-    const trimmed = chatInput.trim();
-    if (!trimmed) return;
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, "0");
-    const mm = String(now.getMinutes()).padStart(2, "0");
-    const today = now.toISOString().slice(0, 10);
-    setChatHistory((prev) => [
-      ...prev,
-      { sender: "Sam", message: trimmed, time: `${hh}:${mm}`, date: today },
-    ]);
-    setSelectedChatDate(today);
-    setCalendarMonth(today.slice(0, 7));
-    setChatInput("");
-  }
-
   function handleAvatarUpload(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -858,167 +1009,87 @@ export default function Supervisor() {
     event.target.value = "";
   }
 
-  function changeCalendarMonth(offset: number) {
-    const [yearStr, monthStr] = calendarMonth.split("-");
-    const date = new Date(Number(yearStr), Number(monthStr) - 1 + offset, 1);
-    setCalendarMonth(
-      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`
-    );
-  }
-
   return (
     <div className="min-h-screen bg-[#f3f4f6] font-serif">
       <div className="mx-auto max-w-7xl px-3 pb-10 pt-8">
         <DashboardHeader
           title="HoD Dashboard"
-          hasNewMessage={hasNewMessage}
-          onMessageClick={openMessagePanel}
+          hasNewMessage={hodUnreadReportCount > 0}
+          onMessageClick={() => setHodReportInboxOpen(true)}
           greetingName={user.surname}
           onAvatarClick={() => setProfileOpen(true)}
           avatarSrc={avatarSrc}
         />
 
-        {messagePanelOpen && (
+        {hodReportInboxOpen && (
           <div
             className="fixed inset-0 z-[70] flex items-center justify-center bg-black/30 p-4"
-            onClick={() => setMessagePanelOpen(false)}
+            onClick={() => setHodReportInboxOpen(false)}
           >
             <div
-              className="w-full max-w-3xl rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-xl"
+              className="w-full max-w-3xl rounded-2xl border-2 border-[#2f4d9c] bg-slate-50 p-6 shadow-xl"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="mb-4 flex items-center justify-between">
-                <div className="text-3xl font-semibold text-slate-800">Contact Admin</div>
+              <div className="-mx-6 -mt-6 mb-4 flex items-center justify-between rounded-t-2xl bg-[#2f4d9c] px-6 py-4 text-white">
+                <div className="text-2xl font-semibold">Annual Department Reports</div>
                 <button
                   type="button"
-                  aria-label="Close"
-                  className="rounded p-1 text-slate-500 hover:bg-slate-200"
-                  onClick={() => setMessagePanelOpen(false)}
+                  aria-label="Close report inbox"
+                  className="rounded p-1 text-white/90 hover:bg-white/20"
+                  onClick={() => setHodReportInboxOpen(false)}
                 >
                   ✕
                 </button>
               </div>
-
-              <div className="mb-4 rounded-lg border border-slate-200 bg-white p-4">
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="text-sm font-semibold text-slate-700">Chat Record Date</div>
-                  <div className="relative">
+              {hodAnnualReports.length === 0 ? (
+                <div className="rounded-md border border-[#2f4d9c]/30 bg-white px-4 py-5 text-sm text-slate-700">
+                  No annual department report generated yet.
+                </div>
+              ) : (
+                <>
+                  <div className="max-h-80 overflow-y-auto rounded-md border border-[#2f4d9c]/40 bg-white">
+                    {pagedHodAnnualReports.map((report) => (
+                      <div
+                        key={report.id}
+                        className="flex items-center justify-between gap-3 border-b border-[#2f4d9c]/10 px-4 py-3"
+                      >
+                        <div className="text-sm font-semibold text-slate-800">{report.title}</div>
+                        <button
+                          type="button"
+                          onClick={() => handleDownloadHodAnnualReport(report)}
+                          className="inline-flex items-center gap-2 rounded border border-[#2f4d9c]/40 bg-[#eef3ff] px-3 py-1 text-xs font-semibold text-[#2f4d9c] hover:bg-[#e0e9ff]"
+                        >
+                          ⬇ Download
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between px-1 text-sm">
                     <button
                       type="button"
-                      onClick={() => setCalendarOpen((v) => !v)}
-                      className="inline-flex items-center gap-2 rounded border border-slate-300 bg-white px-3 py-1 text-sm text-slate-800"
+                      onClick={() => setHodReportInboxPage((p) => Math.max(1, p - 1))}
+                      disabled={hodReportInboxPage <= 1}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                      {selectedChatDate}
-                      <span aria-hidden="true">📅</span>
+                      Previous
                     </button>
-                    {calendarOpen && (
-                      <div className="absolute z-20 mt-2 w-72 rounded-lg border border-slate-200 bg-white p-3 shadow-lg">
-                        <div className="mb-2 flex items-center justify-between">
-                          <button
-                            type="button"
-                            onClick={() => changeCalendarMonth(-1)}
-                            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
-                          >
-                            ‹
-                          </button>
-                          <div className="text-sm font-semibold text-slate-700">{calendarMonth}</div>
-                          <button
-                            type="button"
-                            onClick={() => changeCalendarMonth(1)}
-                            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
-                          >
-                            ›
-                          </button>
-            </div>
-
-                        <div className="mb-1 grid grid-cols-7 gap-1 text-center text-xs font-semibold text-slate-500">
-                          {["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((d) => (
-                            <div key={d}>{d}</div>
-                          ))}
-                        </div>
-
-                        <div className="grid grid-cols-7 gap-1">
-                          {(() => {
-                            const [yearStr, monthStr] = calendarMonth.split("-");
-                            const year = Number(yearStr);
-                            const month = Number(monthStr) - 1;
-                            const firstDay = new Date(year, month, 1).getDay();
-                            const totalDays = new Date(year, month + 1, 0).getDate();
-                            const cells = [];
-
-                            for (let i = 0; i < firstDay; i += 1) {
-                              cells.push(<div key={`empty-${i}`} />);
-                            }
-
-                            for (let day = 1; day <= totalDays; day += 1) {
-                              const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(
-                                2,
-                                "0"
-                              )}`;
-                              const selectable = availableChatDates.has(dateKey);
-                              const isSelected = selectedChatDate === dateKey;
-
-                              cells.push(
-                                <button
-                                  key={dateKey}
-                                  type="button"
-                                  disabled={!selectable}
-                                  onClick={() => {
-                                    setSelectedChatDate(dateKey);
-                                    setCalendarOpen(false);
-                                  }}
-                                  className={`h-8 rounded text-xs ${
-                                    !selectable
-                                      ? "cursor-not-allowed bg-slate-100 text-slate-300"
-                                      : isSelected
-                                        ? "bg-[#2f4d9c] text-white"
-                                        : "text-slate-700 hover:bg-slate-100"
-                                  }`}
-                                >
-                                  {day}
-                                </button>
-                              );
-                            }
-
-                            return cells;
-                          })()}
-            </div>
-                      </div>
-                    )}
+                    <span className="text-slate-600">
+                      Page {hodReportInboxPage} / {hodReportTotalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setHodReportInboxPage((p) => Math.min(hodReportTotalPages, p + 1))}
+                      disabled={hodReportInboxPage >= hodReportTotalPages}
+                      className="rounded border border-[#2f4d9c]/35 bg-[#eef3ff] px-3 py-1 font-semibold text-[#2f4d9c] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Next
+                    </button>
                   </div>
-                </div>
-                <div className="max-h-72 space-y-2 overflow-y-auto pr-1 font-mono text-[15px] leading-6 text-slate-800">
-                  {visibleChatHistory.length > 0 ? (
-                    visibleChatHistory.map((entry, idx) => (
-                      <div key={idx}>
-                        <span className="text-slate-500">[{entry.time}]</span>{" "}
-                        <span className="font-semibold">{entry.sender}:</span> {entry.message}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="text-sm text-slate-500">No chat records for this date.</div>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-end gap-3">
-                <textarea
-                  value={chatInput}
-                  onChange={(e) => setChatInput(e.target.value)}
-                  placeholder="Write your message..."
-                  className="h-16 flex-1 resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-base text-slate-800 outline-none focus:border-[#2f4d9c]"
-                />
-                <button
-                  type="button"
-                  onClick={handleSendMessage}
-                  className="rounded-lg bg-[#2f4d9c] px-5 py-2 text-sm font-semibold text-white hover:bg-[#264183]"
-                >
-                  Send
-                </button>
+                </>
+              )}
             </div>
-            </div>
-        </div>
-      )}
+          </div>
+        )}
 
         <ProfileModal
           open={profileOpen}
@@ -1252,6 +1323,7 @@ export default function Supervisor() {
                     <th className="w-14 px-2 py-2">Task</th>
                     <th className="px-3 py-2">NAME</th>
                     <th className="px-3 py-2">TITLE</th>
+                    <th className="w-[180px] px-3 py-2">REASONS</th>
                     <th className="px-3 py-2">DEPARTMENT</th>
                     <th className="px-3 py-2">STATUS</th>
                     <th className="px-3 py-2 text-center">TOTAL WORK HOURS</th>
@@ -1261,7 +1333,7 @@ export default function Supervisor() {
                 <tbody className="divide-y divide-slate-200 bg-white">
                   {loading && (
                     <tr>
-                      <td colSpan={8} className="px-3 py-6 text-center text-sm text-slate-500">
+                      <td colSpan={9} className="px-3 py-6 text-center text-sm text-slate-500">
                         Loading...
                       </td>
                     </tr>
@@ -1269,7 +1341,7 @@ export default function Supervisor() {
 
                   {!loading && pageItems.length === 0 && (
                     <tr>
-                      <td colSpan={8} className="px-3 py-6 text-center text-sm text-slate-500">
+                      <td colSpan={9} className="px-3 py-6 text-center text-sm text-slate-500">
                         {statusFilter === "pending"
                           ? "No pending requests"
                           : "No items found"}
@@ -1325,6 +1397,14 @@ export default function Supervisor() {
                             <div className="text-xs text-slate-400">{item.studentId}</div>
                           </td>
                           <td className="px-3 py-3 text-slate-700">{item.title}</td>
+                          <td className="px-3 py-3 text-slate-600">
+                            <div
+                              className="max-w-[180px] truncate"
+                              title={requestReasonText(item) || "No reason provided"}
+                            >
+                              {requestReasonText(item) || "—"}
+                            </div>
+                          </td>
                           <td className="px-3 py-3 text-slate-600">{item.department || "—"}</td>
                           <td className="px-3 py-3">
                             <StatusPill status={item.status} variant="supervisor" />
@@ -1607,11 +1687,7 @@ export default function Supervisor() {
                         <div className="text-sm font-semibold text-slate-700">Application Reason</div>
                         <textarea
                           readOnly
-                          value={
-                            detailsItem.requestReason ||
-                            extractRequestReason(detailsItem.description ?? "") ||
-                            "- no reason provided -"
-                          }
+                          value={requestReasonText(detailsItem) || "- no reason provided -"}
                           className="mt-2 h-24 w-full resize-none rounded-sm border border-slate-300 bg-white px-4 py-3 text-sm text-slate-700"
                         />
                       </div>

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -1445,20 +1445,12 @@ export default function Supervisor() {
                   <div className="rounded-sm border border-black">
                     {/* Header */}
                     <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
-                      <div className="flex items-center gap-3">
-                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                          {(() => {
-                            const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
-                            if (!matched) return detailsItem.semesterLabel;
-                            return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}`;
-                          })()}
-                        </div>
-                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                          {detailsItem.department}
-                        </div>
-                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
-                          Academic
-                        </div>
+                      <div className="text-lg font-bold">
+                        {(() => {
+                          const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
+                          const period = matched ? `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}` : detailsItem.semesterLabel;
+                          return `${period}-${detailsItem.department}-Academic`;
+                        })()}
                       </div>
                       <button
                         type="button"

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -1444,21 +1444,29 @@ export default function Supervisor() {
                 >
                   <div className="rounded-sm border border-black">
                     {/* Header */}
-                    <div className="flex items-center justify-between gap-4 border-b border-black/30 bg-white px-5 py-3">
+                    <div className="flex items-center justify-between rounded-t-sm bg-[#2f4d9c] px-5 py-3 text-white">
                       <div className="flex items-center gap-3">
-                        <div className="rounded-sm bg-[#2f4d9c] px-4 py-2 text-sm font-bold text-white tabular-nums font-sans">
-                          2025-S1-Physics
+                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                          {(() => {
+                            const matched = detailsItem.periodLabel.match(/^(\d{4})-(1|2)$/);
+                            if (!matched) return detailsItem.semesterLabel;
+                            return `${matched[1]}-${matched[2] === "1" ? "S1" : "S2"}`;
+                          })()}
+                        </div>
+                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                          {detailsItem.department}
+                        </div>
+                        <div className="rounded bg-white/15 px-3 py-1 text-xs font-semibold">
+                          Academic
                         </div>
                       </div>
-                      <div className="flex items-center gap-3 text-sm font-semibold text-slate-800">
-                        <button
-                          type="button"
-                          onClick={requestCloseDetails}
-                          className="rounded bg-slate-200 px-3 py-1 text-xs font-bold text-slate-700 hover:bg-slate-300"
-                        >
-                          Close
-                        </button>
-                      </div>
+                      <button
+                        type="button"
+                        onClick={requestCloseDetails}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-white/10 hover:bg-white/20"
+                      >
+                        <span className="text-xl leading-none">×</span>
+                      </button>
                     </div>
 
                     {/* Form body */}


### PR DESCRIPTION
Updated frontend routing for HoD and HoS related pages, including /department-head and /school-head.
Added a bilingual HoD / HoS frontend API alignment document to clarify expected backend endpoints, page behaviour, data fields, approval logic, report export, and permission assignment rules.
Improved the Academic submission flow so submitted workload requests keep a proper source workload ID, detail snapshot, and synced pending / approved / rejected status.
Added better localStorage-based status and note synchronisation between Academic, HoD, HoS, and School Operations mock workflows.
Improved HoS workload approval page by aligning the detail modal structure with HoD, including workload breakdown tabs such as Teaching, Assigned Roles, HDR, Service, and Research residual.
Added editable workload breakdown handling in the HoS detail modal, including row validation before closing or approving / rejecting.
Reworked HoS search filters to use a simpler name-based search instead of separate first name / last name / title filters.
Added HoS semester distribution report inbox logic, unread report count, pagination, demo report seeding, and Excel download support.
Added School Operations semester report inbox and Excel download support to better match the HoS report workflow.
Adjusted School Operations export and display logic so newly distributed workloads show - until Academic users actually submit or confirm their requests.
Cleaned up the staff import template by removing unnecessary is_new_employee and notes columns from the generated template.
Added frontend notes for backend integration order and known issues, such as the HoD role card route still needing correction in Role.tsx.