### PR TITLE
fix(api): guard superseded workload decisions

### DIFF
--- a/backend/api/services/workload_service.py
+++ b/backend/api/services/workload_service.py
@@ -4,6 +4,19 @@ from api.models import WorkloadReport
 
 POINT_TO_HOURS = Decimal('17.25')
 
+STALE_REPORT_ERROR = {
+    'success': False,
+    'code': 'REPORT_SUPERSEDED',
+    'message': 'This record has been superseded by a newer import. Please reload the page and retry.',
+}
+
+
+def stale_report_response_payload(extra=None):
+    payload = dict(STALE_REPORT_ERROR)
+    if extra:
+        payload.update(extra)
+    return payload
+
 
 def get_workload_queryset(staff):
     """

--- a/backend/api/view/hod_views.py
+++ b/backend/api/view/hod_views.py
@@ -20,8 +20,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.decorators import require_role
-from api.models import AuditLog, WorkloadItem
-from api.services.workload_service import get_workload_queryset
+from api.models import AuditLog, WorkloadItem, WorkloadReport
+from api.services.workload_service import get_workload_queryset, stale_report_response_payload
 
 
 CATEGORY_LABELS = {
@@ -337,7 +337,15 @@ def hod_workload_request_decision(request, id):
         )
 
     qs = _hod_visible_qs(request.staff)
-    report = get_object_or_404(qs, report_id=id)
+    report = qs.filter(report_id=id).first()
+    if report is None:
+        stale = WorkloadReport.objects.filter(report_id=id, is_current=False).first()
+        if stale is not None:
+            return Response(stale_report_response_payload(), status=http_status.HTTP_409_CONFLICT)
+        return Response(
+            {'success': False, 'message': 'Report not found'},
+            status=http_status.HTTP_404_NOT_FOUND,
+        )
 
     if report.status != 'PENDING':
         return Response(

--- a/backend/api/view/hos_v3_views.py
+++ b/backend/api/view/hos_v3_views.py
@@ -20,6 +20,7 @@ from rest_framework.response import Response
 
 from api.decorators import require_role
 from api.models import AuditLog, WorkloadItem, WorkloadReport
+from api.services.workload_service import stale_report_response_payload
 from api.view.hod_views import (
     _first,
     _parse_breakdown,
@@ -163,7 +164,15 @@ def hos_workload_request_decision(request, id):
         )
 
     qs = _hos_visible_qs()
-    report = get_object_or_404(qs, report_id=id)
+    report = qs.filter(report_id=id).first()
+    if report is None:
+        stale = WorkloadReport.objects.filter(report_id=id, is_current=False).first()
+        if stale is not None:
+            return Response(stale_report_response_payload(), status=http_status.HTTP_409_CONFLICT)
+        return Response(
+            {'success': False, 'message': 'Report not found'},
+            status=http_status.HTTP_404_NOT_FOUND,
+        )
 
     if report.status != 'PENDING':
         return Response(

--- a/backend/api/view/ops_admin_views.py
+++ b/backend/api/view/ops_admin_views.py
@@ -43,6 +43,7 @@ from api.services.workload_service import (
     _parse_year_range,
     persist_report_anomaly,
     evaluate_mvp_anomaly,
+    stale_report_response_payload,
 )
 from api.services.audit_service import compute_diffs, write_audit
 from api.view.supervisor_views import (
@@ -493,6 +494,17 @@ def admin_batch_decision(request):
     reports = list(qs.filter(report_id__in=request_ids))
 
     if len(reports) != len(request_ids):
+        found_ids = {str(r.report_id) for r in reports}
+        missing_ids = [rid for rid in request_ids if str(rid) not in found_ids]
+        stale_ids = list(
+            WorkloadReport.objects.filter(report_id__in=missing_ids, is_current=False)
+            .values_list('report_id', flat=True)
+        )
+        if stale_ids:
+            return Response(
+                stale_report_response_payload({'errors': {'request_ids': [str(x) for x in stale_ids]}}),
+                status=http_status.HTTP_409_CONFLICT,
+            )
         return Response(
             {'success': False, 'message': 'One or more request ids are invalid or not accessible'},
             status=http_status.HTTP_400_BAD_REQUEST,
@@ -552,7 +564,15 @@ def admin_single_decision(request, id):
         )
 
     qs = _admin_reports_qs(request.staff)
-    report = get_object_or_404(qs, report_id=id)
+    report = qs.filter(report_id=id).first()
+    if report is None:
+        stale = WorkloadReport.objects.filter(report_id=id, is_current=False).first()
+        if stale is not None:
+            return Response(stale_report_response_payload(), status=http_status.HTTP_409_CONFLICT)
+        return Response(
+            {'success': False, 'message': 'Report not found'},
+            status=http_status.HTTP_404_NOT_FOUND,
+        )
 
     if report.status != 'PENDING':
         return Response(

--- a/backend/api/view/supervisor_views.py
+++ b/backend/api/view/supervisor_views.py
@@ -13,7 +13,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.decorators import require_role
-from api.models import AuditLog, WorkloadItem
+from api.models import AuditLog, WorkloadItem, WorkloadReport
 from api.services.audit_service import (
     compute_workload_item_diffs,
     snapshot_workload_items,
@@ -21,6 +21,7 @@ from api.services.audit_service import (
 )
 from api.services.workload_service import (
     get_workload_queryset,
+    stale_report_response_payload,
     _parse_year_range,
     _filter_reports_by_range,
     _build_semester_label,
@@ -319,6 +320,17 @@ def supervisor_batch_decision(request):
     reports = list(qs.filter(report_id__in=request_ids))
 
     if len(reports) != len(request_ids):
+        found_ids = {str(r.report_id) for r in reports}
+        missing_ids = [rid for rid in request_ids if str(rid) not in found_ids]
+        stale_ids = list(
+            WorkloadReport.objects.filter(report_id__in=missing_ids, is_current=False)
+            .values_list('report_id', flat=True)
+        )
+        if stale_ids:
+            return Response(
+                stale_report_response_payload({'errors': {'request_ids': [str(x) for x in stale_ids]}}),
+                status=http_status.HTTP_409_CONFLICT,
+            )
         return Response(
             {'success': False, 'message': 'One or more request ids are invalid or not accessible'},
             status=http_status.HTTP_400_BAD_REQUEST,
@@ -380,7 +392,15 @@ def supervisor_single_decision(request, id):
         )
 
     qs = _hod_visible_qs(request.staff)
-    report = get_object_or_404(qs, report_id=id)
+    report = qs.filter(report_id=id).first()
+    if report is None:
+        stale = WorkloadReport.objects.filter(report_id=id, is_current=False).first()
+        if stale is not None:
+            return Response(stale_report_response_payload(), status=http_status.HTTP_409_CONFLICT)
+        return Response(
+            {'success': False, 'message': 'Report not found'},
+            status=http_status.HTTP_404_NOT_FOUND,
+        )
 
     if report.status != 'PENDING':
         return Response(


### PR DESCRIPTION
## Summary
- Rebase the superseded-report conflict guard onto current `main` after PR #49
- Return `409` with `code=REPORT_SUPERSEDED` when a stale report id is used for decision endpoints
- Preserve the existing guard for legacy supervisor/admin decision paths
- Extend the same guard to new HoD/HoS v3 decision endpoints

## Replaces
This is the clean replacement for PR #46, which now conflicts with current `main` in `supervisor_views.py` and tests.

## Covered Endpoints
- `POST /api/supervisor/workload-requests/{id}/decision/`
- `POST /api/supervisor/workload-requests/batch-decision/`
- `POST /api/admin/workload-requests/{id}/decision/`
- `POST /api/admin/workload-requests/batch-decision/`
- `POST /api/hod/workload-requests/{id}/decision/`
- `POST /api/hos/workload-requests/{id}/decision/`

## Validation
- `python manage.py check`
- `python -m compileall backend/api/services/workload_service.py backend/api/view/supervisor_views.py backend/api/view/ops_admin_views.py backend/api/view/hod_views.py backend/api/view/hos_v3_views.py`
- `git diff --check`