### PR TITLE
Gate School Ops APIs with Django permissions

### DIFF
--- a/backend/api/decorators.py
+++ b/backend/api/decorators.py
@@ -50,3 +50,34 @@ def require_role(*roles):
             return view_func(request, *args, **kwargs)
         return wrapper
     return decorator
+
+
+def require_any_perm(*permissions):
+    """
+    Permission-based access control backed by Django auth.
+
+    Checks request.user.has_perm() for at least one fully qualified permission
+    codename, and still injects request.staff for endpoint business logic.
+    """
+    required = set(permissions)
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            staff = get_object_or_404(Staff, user=request.user)
+            if not staff.is_active:
+                return Response(
+                    {"code": "ACCOUNT_INACTIVE", "message": "Account is inactive."},
+                    status=403,
+                )
+
+            if not any(request.user.has_perm(permission) for permission in required):
+                return Response(
+                    {"code": "FORBIDDEN", "message": "You do not have permission to access this resource."},
+                    status=403,
+                )
+
+            request.staff = staff
+            return view_func(request, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/backend/api/management/commands/initialize_rbac.py
+++ b/backend/api/management/commands/initialize_rbac.py
@@ -29,6 +29,7 @@ ROLE_PERMISSIONS: dict[str, list[str]] = {
     "view_hod_page":          ["HOD"],
     "view_school_ops_page":   ["SCHOOL_OPS"],
     "view_hos_page":          ["HOS"],
+    "access_school_ops_api":  ["SCHOOL_OPS", "HOS"],
     "approve_workload_dept":  ["HOD"],
     "approve_workload_school":["HOS"],
     "import_workload":        ["SCHOOL_OPS"],
@@ -41,6 +42,7 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **opts):
+        verbosity = int(opts.get("verbosity", 1))
         staff_ct = ContentType.objects.get_for_model(Staff)
 
         # Ensure every codename exists as a Django Permission.
@@ -63,8 +65,10 @@ class Command(BaseCommand):
                 if role in roles
             ]
             group.permissions.set(desired)
-            self.stdout.write(
-                f"  Group {role}: {len(desired)} permissions"
-            )
+            if verbosity:
+                self.stdout.write(
+                    f"  Group {role}: {len(desired)} permissions"
+                )
 
-        self.stdout.write(self.style.SUCCESS("initialize_rbac: OK"))
+        if verbosity:
+            self.stdout.write(self.style.SUCCESS("initialize_rbac: OK"))

--- a/backend/api/migrations/0010_staff_access_school_ops_api.py
+++ b/backend/api/migrations/0010_staff_access_school_ops_api.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0009_staff_permissions'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='staff',
+            options={
+                'permissions': [
+                    ('view_academic_page', 'Can view Academic page'),
+                    ('view_hod_page', 'Can view HoD page'),
+                    ('view_school_ops_page', 'Can view School Operations page'),
+                    ('view_hos_page', 'Can view Head of School page'),
+                    ('access_school_ops_api', 'Can access School Operations API'),
+                    ('approve_workload_dept', 'Can approve workload at department level'),
+                    ('approve_workload_school', 'Can approve workload at school level'),
+                    ('import_workload', 'Can import workload Excel'),
+                    ('manage_staff', 'Can create or edit staff records'),
+                ],
+            },
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -165,6 +165,7 @@ class Staff(models.Model):
             ("view_hod_page",           "Can view HoD page"),
             ("view_school_ops_page",    "Can view School Operations page"),
             ("view_hos_page",           "Can view Head of School page"),
+            ("access_school_ops_api",   "Can access School Operations API"),
             ("approve_workload_dept",   "Can approve workload at department level"),
             ("approve_workload_school", "Can approve workload at school level"),
             ("import_workload",         "Can import workload Excel"),

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1458,6 +1458,36 @@ class TestAdminOpsContract(BaseTestCase):
         self.assertEqual(disabled.status_code, 200)
         self.assertEqual(disabled.data['data']['status'], 'disabled')
 
+    def test_admin_role_assignment_replaces_previous_active_role(self):
+        client = self._auth_client(self.ops)
+        first = client.post('/api/admin/role-assignments/', {
+            'staff_id': self.academic.staff_number,
+            'role': 'HoD',
+            'department': self.dept_csse.name,
+            'permissions': ['View Workload'],
+        }, format='json')
+        self.assertEqual(first.status_code, 201)
+
+        second = client.post('/api/admin/role-assignments/', {
+            'staff_id': self.academic.staff_number,
+            'role': 'Admin',
+            'department': 'Senior School Coordinator',
+            'permissions': ['Distribute Workload to Departments'],
+        }, format='json')
+        self.assertEqual(second.status_code, 201)
+
+        first_assignment = StaffRoleAssignment.objects.get(assignment_id=first.data['data']['id'])
+        self.assertEqual(first_assignment.status, 'disabled')
+        self.assertEqual(first_assignment.disable_reason, 'Superseded by a newer role assignment.')
+
+        active = StaffRoleAssignment.objects.filter(staff=self.academic, status='active')
+        self.assertEqual(active.count(), 1)
+        self.assertEqual(active.get().assignment_id, second.data['data']['id'])
+
+        self.academic.refresh_from_db()
+        self.assertEqual(self.academic.role, 'SCHOOL_OPS')
+        self.assertTrue(self.academic.user.groups.filter(name='SCHOOL_OPS').exists())
+
     def test_admin_export_manifest_and_download_roundtrip(self):
         client = self._auth_client(self.ops)
         manifest = client.get('/api/admin/export/')

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1458,15 +1458,28 @@ class TestAdminOpsContract(BaseTestCase):
         self.assertEqual(disabled.status_code, 200)
         self.assertEqual(disabled.data['data']['status'], 'disabled')
 
+        active_listing = client.get('/api/admin/role-assignments/')
+        self.assertEqual(active_listing.status_code, 200)
+        active_ids = {row['id'] for row in active_listing.data['data']['items']}
+        self.assertNotIn(assignment_id, active_ids)
+
+        history_listing = client.get('/api/admin/role-assignments/?includeDisabled=true')
+        self.assertEqual(history_listing.status_code, 200)
+        history_ids = {row['id'] for row in history_listing.data['data']['items']}
+        self.assertIn(assignment_id, history_ids)
+
     def test_admin_role_assignment_replaces_previous_active_role(self):
         client = self._auth_client(self.ops)
         first = client.post('/api/admin/role-assignments/', {
             'staff_id': self.academic.staff_number,
             'role': 'HoD',
-            'department': self.dept_csse.name,
+            'department': self.dept_physics.name,
             'permissions': ['View Workload'],
         }, format='json')
         self.assertEqual(first.status_code, 201)
+        self.academic.refresh_from_db()
+        self.assertEqual(self.academic.role, 'HOD')
+        self.assertEqual(self.academic.department, self.dept_physics)
 
         second = client.post('/api/admin/role-assignments/', {
             'staff_id': self.academic.staff_number,
@@ -1487,6 +1500,40 @@ class TestAdminOpsContract(BaseTestCase):
         self.academic.refresh_from_db()
         self.assertEqual(self.academic.role, 'SCHOOL_OPS')
         self.assertTrue(self.academic.user.groups.filter(name='SCHOOL_OPS').exists())
+
+        listing = client.get('/api/admin/role-assignments/')
+        self.assertEqual(listing.status_code, 200)
+        rows = [row for row in listing.data['data']['items'] if row['staff_id'] == self.academic.staff_number]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['id'], second.data['data']['id'])
+
+    def test_admin_role_assignment_disable_unknown_latest_role_resyncs_group(self):
+        client = self._auth_client(self.ops)
+        self.academic.role = 'HOD'
+        self.academic.save(update_fields=['role', 'updated_at'])
+        self.academic.user.groups.clear()
+
+        StaffRoleAssignment.objects.create(
+            staff=self.academic,
+            role_code='Legacy',
+            department_scope=self.dept_csse.name,
+            permissions=[],
+            status='active',
+        )
+        current = StaffRoleAssignment.objects.create(
+            staff=self.academic,
+            role_code='Admin',
+            department_scope='Senior School Coordinator',
+            permissions=[],
+            status='active',
+        )
+
+        disabled = client.post(f'/api/admin/role-assignments/{current.assignment_id}/disable/', {}, format='json')
+        self.assertEqual(disabled.status_code, 200)
+
+        self.academic.refresh_from_db()
+        self.assertEqual(self.academic.role, 'HOD')
+        self.assertTrue(self.academic.user.groups.filter(name='HOD').exists())
 
     def test_admin_export_manifest_and_download_roundtrip(self):
         client = self._auth_client(self.ops)

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -2,8 +2,9 @@ from datetime import timedelta
 from decimal import Decimal
 from io import BytesIO
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
 from django.utils import timezone
 from rest_framework.test import APITestCase, APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -37,6 +38,8 @@ class BaseTestCase(APITestCase):
     """
 
     def setUp(self):
+        call_command('initialize_rbac', verbosity=0)
+
         # Two departments — used to verify HOD cannot cross department boundaries
         self.dept_csse = Department.objects.create(name='CSSE')
         self.dept_physics = Department.objects.create(name='Physics')
@@ -99,6 +102,32 @@ class BaseTestCase(APITestCase):
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
         return client
+
+    def _item_ids(self, res):
+        """Extract report id list from a paginated workload list response."""
+        return [item['id'] for item in res.data['items']]
+
+    def _submit_report(self, report, staff=None):
+        """Academic submits a WORKLOAD_REQUEST so HOD can act on the report."""
+        actor = staff or self.academic
+        AuditLog.objects.create(
+            report=report,
+            action_by=actor,
+            action_type='COMMENT',
+            comment='Submitting for review.',
+            changes={'kind': 'WORKLOAD_REQUEST', 'status': 'pending'},
+        )
+        report.status = 'PENDING'
+        report.save(update_fields=['status', 'updated_at'])
+
+    def _confirm_report_via_api(self, report, staff=None):
+        """Confirm one report via the public API."""
+        actor = staff or self.academic
+        client = self._auth_client(actor)
+        return client.post(
+            f'/api/academic/workloads/{report.report_id}/confirm/',
+            format='json',
+        )
 
 
 class TestOTPTokenModel(APITestCase):
@@ -1168,6 +1197,45 @@ class TestHoSContractEndpoints(BaseTestCase):
         self.assertEqual(rows[0]['role'], 'Admin')
         self.assertEqual(rows[0]['status'], 'active')
 
+    def test_hos_v3_admin_assignment_grants_ops_group_and_permission(self):
+        hos_client = self._auth_client(self.hos)
+        create = hos_client.post(
+            '/api/hos/role-assignments',
+            data={
+                'staffId': self.academic.staff_number,
+                'role': 'Admin',
+                'department': 'Senior School Coordinator',
+                'permissions': ['Distribute Workload to Departments'],
+            },
+            format='json',
+        )
+        self.assertEqual(create.status_code, 201)
+
+        self.academic.refresh_from_db()
+        self.academic.user = User.objects.get(pk=self.academic.user_id)
+        self.assertEqual(self.academic.role, 'SCHOOL_OPS')
+        self.assertTrue(self.academic.user.groups.filter(name='SCHOOL_OPS').exists())
+        self.assertTrue(self.academic.user.has_perm('api.access_school_ops_api'))
+
+        assigned_client = self._auth_client(self.academic)
+        ops_res = assigned_client.get('/api/admin/workload-requests/')
+        self.assertEqual(ops_res.status_code, 200)
+
+        disable = hos_client.patch(
+            f"/api/hos/role-assignments/{create.data['id']}/status",
+            data={'status': 'disabled', 'reason': 'Permission no longer required'},
+            format='json',
+        )
+        self.assertEqual(disable.status_code, 200)
+
+        self.academic.refresh_from_db()
+        self.academic.user = User.objects.get(pk=self.academic.user_id)
+        self.assertEqual(self.academic.role, 'ACADEMIC')
+        self.assertFalse(self.academic.user.groups.filter(name='SCHOOL_OPS').exists())
+        self.assertFalse(self.academic.user.has_perm('api.access_school_ops_api'))
+        denied = assigned_client.get('/api/admin/workload-requests/')
+        self.assertEqual(denied.status_code, 403)
+
     def test_hos_visualization_contract_shape(self):
         client = self._auth_client(self.hos)
         res = client.get('/api/headofschool/visualization/?from_year=2024&to_year=2026&semester=All')
@@ -1347,6 +1415,14 @@ class TestAdminOpsContract(BaseTestCase):
 
     def test_academic_blocked_from_admin_scope(self):
         client = self._auth_client(self.academic)
+        res = client.get('/api/admin/workload-requests/')
+        self.assertEqual(res.status_code, 403)
+
+    def test_admin_scope_requires_django_permission(self):
+        group = Group.objects.get(name='SCHOOL_OPS')
+        group.permissions.remove(*group.permissions.filter(codename='access_school_ops_api'))
+
+        client = self._auth_client(self.ops)
         res = client.get('/api/admin/workload-requests/')
         self.assertEqual(res.status_code, 403)
 

--- a/backend/api/view/ops_admin_views.py
+++ b/backend/api/view/ops_admin_views.py
@@ -27,7 +27,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 
-from api.decorators import require_role
+from api.decorators import require_any_perm
 from api.models import (
     AuditLog,
     Department,
@@ -53,7 +53,7 @@ from api.view.supervisor_views import (
     _to_decimal_hours,
 )
 
-ADMIN_ROLES = ('SCHOOL_OPS', 'HOS')
+OPS_API_PERMISSION = 'api.access_school_ops_api'
 MAX_EXCEL_UPLOAD_BYTES = 5 * 1024 * 1024
 EXPORT_MEDIA_SUBDIR = 'exports'
 TEMPLATE_MEDIA_SUBDIR = 'templates'
@@ -352,7 +352,7 @@ def _staff_from_body_or_path(request, lookup_id: str):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_workload_requests(request):
     """GET /api/school-operations/workloads  (also /api/admin/workload-requests/)"""
     base_qs = _admin_reports_qs(request.staff).prefetch_related('items').select_related(
@@ -442,7 +442,7 @@ def admin_workload_requests(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_workload_request_detail(request, id):
     """GET /api/school-operations/workloads/{id}  (also /api/admin/workload-requests/{id}/)"""
     qs = (
@@ -462,7 +462,7 @@ def admin_workload_request_detail(request, id):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @transaction.atomic
 def admin_batch_decision(request):
     """POST /api/admin/workload-requests/batch-decision/"""
@@ -534,7 +534,7 @@ def admin_batch_decision(request):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @transaction.atomic
 def admin_single_decision(request, id):
     """POST /api/admin/workload-requests/{id}/decision/"""
@@ -616,7 +616,7 @@ def admin_single_decision(request, id):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @transaction.atomic
 def admin_distribute_workloads(request):
     """POST /api/school-operations/workloads/distribute  (also /api/admin/workloads/distribute/)"""
@@ -762,7 +762,7 @@ def _dispatch_template_download(request, filename: str):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_workload_import_template(request):
     headers = ['employee_id', 'name', 'description', 'total_work_hours', 'status']
     return _admin_template_urls(request, 'workloads/import-template', 'Workload_Template.xlsx', headers, [])
@@ -770,14 +770,14 @@ def admin_workload_import_template(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_workload_import_template_download(request):
     return _dispatch_template_download(request, 'Workload_Template.xlsx')
 
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_staff_import_template(request):
     headers = ['employee_id', 'first_name', 'last_name', 'email', 'department', 'active_status']
     return _admin_template_urls(request, 'staff/import-template', 'Staff_Template.xlsx', headers, [])
@@ -785,14 +785,14 @@ def admin_staff_import_template(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_staff_import_template_download(request):
     return _dispatch_template_download(request, 'Staff_Template.xlsx')
 
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminImportThrottle])
 @transaction.atomic
 def admin_workload_import(request):
@@ -973,7 +973,7 @@ def admin_workload_import(request):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminImportThrottle])
 @transaction.atomic
 def admin_staff_import(request):
@@ -1144,7 +1144,7 @@ def admin_staff_import(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_staff_list(request):
     """GET /api/school-operations/staff  (also /api/admin/staff/)"""
     queryset = Staff.objects.select_related('user', 'department').order_by('staff_number')
@@ -1197,7 +1197,7 @@ def admin_staff_list(request):
 
 @api_view(['GET', 'PATCH'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @transaction.atomic
 def admin_staff_patch(request, staff_id):
     """GET /api/school-operations/staff/{staffId}  or  PATCH /api/school-operations/staff/{staffId}"""
@@ -1324,7 +1324,7 @@ def admin_staff_patch(request, staff_id):
 
 @api_view(['GET', 'POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_role_assignments(request):
     """GET list + POST create."""
     if request.method == 'GET':
@@ -1359,7 +1359,7 @@ def admin_role_assignments(request):
         status='active',
     )
 
-    # Sync Staff.role so require_role() checks take effect immediately.
+    # Keep Staff.role double-written while Django Groups/Permissions drive access.
     _FRONT_TO_CANONICAL = {'HoD': 'HOD', 'Admin': 'SCHOOL_OPS'}
     canonical = _FRONT_TO_CANONICAL.get(role_front)
     if canonical:
@@ -1377,7 +1377,7 @@ def admin_role_assignments(request):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @transaction.atomic
 def admin_role_assignment_disable(request, assignment_id):
     payload = request.data or {}
@@ -1388,6 +1388,26 @@ def admin_role_assignment_disable(request, assignment_id):
     assignment.disable_reason = reason[:500]
     assignment.save(update_fields=['status', 'disable_reason', 'updated_at'])
 
+    latest_active = (
+        StaffRoleAssignment.objects
+        .filter(staff=assignment.staff, status='active')
+        .exclude(assignment_id=assignment.assignment_id)
+        .order_by('-created_at', '-assignment_id')
+        .first()
+    )
+    if latest_active is None:
+        assignment.staff.role = 'ACADEMIC'
+        assignment.staff.save(update_fields=['role', 'updated_at'])
+    else:
+        canonical = {'HoD': 'HOD', 'Admin': 'SCHOOL_OPS'}.get(latest_active.role_code)
+        if canonical:
+            assignment.staff.role = canonical
+            if latest_active.resolved_department_id is not None:
+                assignment.staff.department = latest_active.resolved_department
+                assignment.staff.save(update_fields=['role', 'department', 'updated_at'])
+            else:
+                assignment.staff.save(update_fields=['role', 'updated_at'])
+
     return Response({'success': True, 'message': 'Role assignment disabled', 'data': {
         'id': assignment.assignment_id,
         'status': assignment.status,
@@ -1396,7 +1416,7 @@ def admin_role_assignment_disable(request, assignment_id):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_visualization(request):
     semester_filter = _parse_semester_filter(request)
     year_from, year_to = _parse_year_range(request)
@@ -1501,7 +1521,7 @@ def _persist_export_workbook(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminExportThrottle])
 def admin_export_manifest(request):
     """
@@ -1522,7 +1542,7 @@ def admin_export_manifest(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminExportThrottle])
 def admin_export_download(request):
     """Binary companion for `/admin/export/` JSON contracts."""
@@ -1585,7 +1605,7 @@ def _build_workload_export_workbook(qs):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminExportThrottle])
 def admin_workload_export(request):
     """GET /api/school-operations/workloads/export — direct file stream filtered by status/staff/dept/year/semester."""
@@ -1638,7 +1658,7 @@ def admin_workload_export(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminExportThrottle])
 def admin_school_export(request):
     """GET /api/school-operations/export — school-level history Excel, direct file stream."""
@@ -1667,7 +1687,7 @@ def admin_school_export(request):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 def admin_contact_staff(request):
     """POST /api/school-operations/contact-staff — stub; stores message as AuditLog comment."""
     body = request.data or {}
@@ -1731,7 +1751,7 @@ _AUDIT_ACTION_HUMAN = {
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
-@require_role(*ADMIN_ROLES)
+@require_any_perm(OPS_API_PERMISSION)
 @throttle_classes([AdminExportThrottle])
 def admin_audit_log_export(request):
     """GET /api/school-operations/audit-log/export

--- a/backend/api/view/ops_admin_views.py
+++ b/backend/api/view/ops_admin_views.py
@@ -252,6 +252,15 @@ def _serialize_assignment_row(obj: StaffRoleAssignment):    return {
     }
 
 
+def _dedupe_latest_assignment_by_staff(assignments):
+    latest_by_staff = {}
+    for assignment in assignments:
+        if assignment.staff_id in latest_by_staff:
+            continue
+        latest_by_staff[assignment.staff_id] = assignment
+    return list(latest_by_staff.values())
+
+
 def _build_visualization_payload(reports_queryset, year_from, year_to, semester_filter, dept_label_scope):
     """
     Shape aligns with frontend_api_contract_cn.md §9.11 HoS visualization for Admin reuse.
@@ -1331,8 +1340,18 @@ def admin_role_assignments(request):
     """GET list + POST create."""
     if request.method == 'GET':
         queryset = StaffRoleAssignment.objects.select_related('staff', 'resolved_department').order_by('-created_at')
+        include_disabled = (
+            str(request.GET.get('includeDisabled') or request.GET.get('include_disabled') or '')
+            .strip()
+            .lower()
+            in ('1', 'true', 'yes')
+        )
+        if include_disabled:
+            assignments = list(queryset[:500])
+        else:
+            assignments = _dedupe_latest_assignment_by_staff(list(queryset.filter(status='active')[:500]))
         return Response({'success': True, 'message': 'Assignments loaded', 'data': {
-            'items': [_serialize_assignment_row(obj) for obj in queryset[:500]],
+            'items': [_serialize_assignment_row(obj) for obj in assignments],
         }})
 
     body = request.data or {}
@@ -1350,7 +1369,12 @@ def admin_role_assignments(request):
     if not staff_row:
         return Response({'success': False, 'message': 'staff not found'}, status=http_status.HTTP_404_NOT_FOUND)
 
-    resolved = Department.objects.filter(name__iexact=dept_scope).first()
+    if role_front == 'Admin':
+        resolved = None
+    else:
+        resolved = Department.objects.filter(name__iexact=dept_scope).first()
+        if dept_scope and resolved is None:
+            resolved = Department.objects.create(name=dept_scope)
 
     StaffRoleAssignment.objects.filter(staff=staff_row, status='active').update(
         status='disabled',
@@ -1372,7 +1396,11 @@ def admin_role_assignments(request):
     canonical = _FRONT_TO_CANONICAL.get(role_front)
     if canonical:
         staff_row.role = canonical
-        staff_row.save(update_fields=['role', 'updated_at'])
+        if resolved is not None:
+            staff_row.department = resolved
+            staff_row.save(update_fields=['role', 'department', 'updated_at'])
+        else:
+            staff_row.save(update_fields=['role', 'updated_at'])
 
     return Response({
         'success': True,
@@ -1415,6 +1443,8 @@ def admin_role_assignment_disable(request, assignment_id):
                 assignment.staff.save(update_fields=['role', 'department', 'updated_at'])
             else:
                 assignment.staff.save(update_fields=['role', 'updated_at'])
+        else:
+            assignment.staff.save(update_fields=['role', 'updated_at'])
 
     return Response({'success': True, 'message': 'Role assignment disabled', 'data': {
         'id': assignment.assignment_id,

--- a/backend/api/view/ops_admin_views.py
+++ b/backend/api/view/ops_admin_views.py
@@ -54,6 +54,7 @@ from api.view.supervisor_views import (
 )
 
 OPS_API_PERMISSION = 'api.access_school_ops_api'
+SUPERSEDED_ROLE_REASON = 'Superseded by a newer role assignment.'
 MAX_EXCEL_UPLOAD_BYTES = 5 * 1024 * 1024
 EXPORT_MEDIA_SUBDIR = 'exports'
 TEMPLATE_MEDIA_SUBDIR = 'templates'
@@ -1325,6 +1326,7 @@ def admin_staff_patch(request, staff_id):
 @api_view(['GET', 'POST'])
 @permission_classes([IsAuthenticated])
 @require_any_perm(OPS_API_PERMISSION)
+@transaction.atomic
 def admin_role_assignments(request):
     """GET list + POST create."""
     if request.method == 'GET':
@@ -1349,6 +1351,12 @@ def admin_role_assignments(request):
         return Response({'success': False, 'message': 'staff not found'}, status=http_status.HTTP_404_NOT_FOUND)
 
     resolved = Department.objects.filter(name__iexact=dept_scope).first()
+
+    StaffRoleAssignment.objects.filter(staff=staff_row, status='active').update(
+        status='disabled',
+        disable_reason=SUPERSEDED_ROLE_REASON,
+        updated_at=timezone.now(),
+    )
 
     assignment = StaffRoleAssignment.objects.create(
         staff=staff_row,


### PR DESCRIPTION
## Summary
- add the access_school_ops_api Django permission and migration
- switch School Ops/Admin endpoints to user.has_perm() via a permission decorator
- keep Staff.role double-written for compatibility when HoS/Ops role assignments change
- add regression coverage for HoS Admin assignment granting/revoking Ops API access

## Testing
- python manage.py test api.tests --settings=config.test_settings

## Notes
- Run migrate and initialize_rbac after deployment so existing environments receive the new permission.