### PR TITLE
feat: load visualization data from backend

### DIFF
--- a/backend/api/services/workload_service.py
+++ b/backend/api/services/workload_service.py
@@ -82,6 +82,18 @@ def workload_item_hours_for_totals(item) -> Decimal:
     return item.allocated_hours or Decimal('0.00')
 
 
+def report_research_hours(report) -> Decimal:
+    """Calculated display hours for the Research (residual) breakdown row."""
+    return evaluate_mvp_anomaly(report)['metrics']['research_pts'] * POINT_TO_HOURS
+
+
+def report_total_hours(report, items=None) -> Decimal:
+    """Return the chart/list total using the same 5-tab workload breakdown as the UI."""
+    report_items = list(items) if items is not None else list(report.items.all())
+    item_hours = sum((workload_item_hours_for_totals(item) for item in report_items), Decimal('0.00'))
+    return item_hours + report_research_hours(report)
+
+
 def _teaching_band(calc_tr: Decimal) -> str:
     if calc_tr <= Decimal('0.20'):
         return 'Research Focused'
@@ -227,6 +239,29 @@ def _filter_reports_by_range(qs, year_from, year_to, semester_filter):
 
 def _build_semester_label(year: int, semester: str) -> str:
     return f"{year} {semester}"
+
+
+def semester_sort_key(label_or_pair):
+    sem_order = {'S1': 0, 'S2': 1, 'FULL_YEAR': 2}
+    if isinstance(label_or_pair, tuple):
+        year, semester = label_or_pair
+        return int(year or 0), sem_order.get(str(semester or '').upper(), 9)
+
+    parts = str(label_or_pair or '').replace('-', ' ').split()
+    year = 0
+    semester = ''
+    if parts:
+        try:
+            year = int(parts[0])
+        except (TypeError, ValueError):
+            year = 0
+    if len(parts) > 1:
+        raw_sem = parts[1].upper()
+        if raw_sem in {'1', '2'}:
+            semester = f"S{raw_sem}"
+        else:
+            semester = f"S{raw_sem[-1]}" if raw_sem.startswith('SEM') and raw_sem[-1].isdigit() else raw_sem
+    return year, sem_order.get(semester, 9)
 
 
 def _reporting_period_label(year_from, year_to, semester_filter) -> str:

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -797,6 +797,64 @@ class TestAcademicVisualization(BaseTestCase):
 
 # ─── Test: export endpoint ────────────────────────────────────────────────────
 
+class TestVisualizationRealData(BaseTestCase):
+    def _seed_seven_semesters(self, status='PENDING'):
+        WorkloadReport.objects.all().delete()
+        periods = [
+            (2022, 'S1'),
+            (2022, 'S2'),
+            (2023, 'S1'),
+            (2023, 'S2'),
+            (2024, 'S1'),
+            (2024, 'S2'),
+            (2025, 'S1'),
+        ]
+        reports = []
+        for idx, (year, semester) in enumerate(periods, start=1):
+            report = WorkloadReport.objects.create(
+                staff=self.academic,
+                academic_year=year,
+                semester=semester,
+                snapshot_fte=Decimal('1.00'),
+                snapshot_department=self.dept_csse,
+                status=status,
+                distributed_at=timezone.now(),
+            )
+            WorkloadItem.objects.create(
+                report=report,
+                category='TEACHING',
+                unit_code=f'CITS{idx:04d}',
+                allocated_hours=Decimal('86.25'),
+            )
+            reports.append(report)
+        return reports
+
+    def test_school_ops_visualization_reads_seven_semesters_from_database(self):
+        self._seed_seven_semesters()
+        client = self._auth_client(self.ops)
+        res = client.get('/api/school-operations/visualization?fromYear=2022&toYear=2025&semester=All')
+        self.assertEqual(res.status_code, 200)
+        data = res.data['data']
+        self.assertEqual(len(data['trend']), 7)
+        self.assertEqual(data['trend'][0]['semester'], '2022 S1')
+        self.assertEqual(data['trend'][-1]['semester'], '2025 S1')
+        self.assertEqual(data['summary']['totalAcademics'], 1)
+        self.assertEqual(data['summary']['pendingRequests'], 7)
+        self.assertEqual(data['departmentStats'][0]['academics'], 1)
+
+    def test_hos_v3_analytics_includes_department_stats_and_seven_semester_trend(self):
+        self._seed_seven_semesters()
+        client = self._auth_client(self.hos)
+        res = client.get('/api/hos/analytics/workloads?fromYear=2022&toYear=2025&semester=All')
+        self.assertEqual(res.status_code, 200)
+        data = res.data['data']
+        self.assertEqual(len(data['departmentWorkloadTrend']), 7)
+        self.assertEqual(data['departmentWorkloadTrend'][0]['semester'], '2022 S1')
+        self.assertEqual(data['departmentWorkloadTrend'][-1]['semester'], '2025 S1')
+        self.assertEqual(data['departmentStats'][0]['academics'], 1)
+        self.assertEqual(data['departmentStats'][0]['pending'], 7)
+
+
 class TestAcademicExport(BaseTestCase):
     """
     Verifies GET /api/academic/export/ returns a real xlsx binary stream.

--- a/backend/api/view/academic_views.py
+++ b/backend/api/view/academic_views.py
@@ -17,11 +17,13 @@ from api.permissions import IsAcademicOrHoD
 from api.services.workload_service import (
     evaluate_mvp_anomaly,
     staff_has_role,
+    report_total_hours,
     workload_item_hours_for_totals,
     _parse_year_range,
     _filter_reports_by_range,
     _build_semester_label,
     _reporting_period_label,
+    semester_sort_key,
 )
 from api.view.supervisor_views import _get_request_reason
 from api.view.ops_admin_views import _serialize_workload_detail as _serialize_ops_workload_detail
@@ -506,19 +508,18 @@ def academic_visualization(request):
     qs = _own_reports_qs(request.staff).prefetch_related('items')
     qs = _filter_reports_by_range(qs, year_from, year_to, semester_filter)
 
-    SEM_ORDER = {'S1': 0, 'S2': 1, 'FULL_YEAR': 2}
     reports = list(qs.order_by('academic_year', 'semester'))
 
     seen = {}
     for r in reports:
         key = (r.academic_year, r.semester)
         seen[key] = True
-    ordered_keys = sorted(seen.keys(), key=lambda k: (k[0], SEM_ORDER.get(k[1], 9)))
+    ordered_keys = sorted(seen.keys(), key=semester_sort_key)
 
     my_hours_map = {}
     for r in reports:
         key = (r.academic_year, r.semester)
-        total = sum((workload_item_hours_for_totals(item) for item in r.items.all()), Decimal('0.00'))
+        total = report_total_hours(r)
         my_hours_map[key] = my_hours_map.get(key, Decimal('0.00')) + total
 
     dept_id = request.staff.department_id
@@ -531,7 +532,7 @@ def academic_visualization(request):
     dept_hours_map = {}
     for r in dept_qs.order_by('academic_year', 'semester'):
         key = (r.academic_year, r.semester)
-        total = sum((workload_item_hours_for_totals(item) for item in r.items.all()), Decimal('0.00'))
+        total = report_total_hours(r)
         dept_hours_map.setdefault(key, []).append(total)
 
     my_vs_dept = []

--- a/backend/api/view/hod_views.py
+++ b/backend/api/view/hod_views.py
@@ -30,6 +30,9 @@ from api.services.workload_service import (
     _reporting_period_label,
     evaluate_mvp_anomaly,
     get_workload_queryset,
+    report_research_hours,
+    report_total_hours,
+    semester_sort_key,
     stale_report_response_payload,
     workload_item_hours_for_totals,
 )
@@ -116,7 +119,7 @@ def _report_item_hours(items) -> Decimal:
 
 
 def _report_research_hours(report) -> Decimal:
-    return evaluate_mvp_anomaly(report)['metrics']['research_pts'] * Decimal('17.25')
+    return report_research_hours(report)
 
 
 def _serialize_breakdown(items, report=None):
@@ -319,8 +322,7 @@ def _serialize_detail(report):
 
 
 def _report_total_hours(report, items=None) -> Decimal:
-    report_items = list(items) if items is not None else list(report.items.all())
-    return _report_item_hours(report_items) + _report_research_hours(report)
+    return report_total_hours(report, items)
 
 
 def _report_period_id(prefix: str, year, semester, department='') -> str:
@@ -439,18 +441,43 @@ def _analytics_payload(qs, year_from, year_to, semester_filter, scope_label):
     trend = {}
     status_distribution = {'pending': 0, 'approved': 0, 'rejected': 0, 'initial': 0}
     hours_distribution = {}
+    department_stats = {}
+    department_trend = {}
     for report in reports:
         label = _period_label(report.academic_year, report.semester)
+        semester_label = f"{report.academic_year} {report.semester}"
+        dept_name = report.snapshot_department.name
+        total = _report_total_hours(report)
         bucket = trend.setdefault(label, {'period': label, 'totalWorkHours': Decimal('0.00'), 'staff': set()})
-        bucket['totalWorkHours'] += _report_total_hours(report)
+        bucket['totalWorkHours'] += total
         bucket['staff'].add(report.staff_id)
         status_distribution[report.status.lower()] = status_distribution.get(report.status.lower(), 0) + 1
-        dept_name = report.snapshot_department.name
-        hours_distribution[dept_name] = hours_distribution.get(dept_name, Decimal('0.00')) + _report_total_hours(report)
+        hours_distribution[dept_name] = hours_distribution.get(dept_name, Decimal('0.00')) + total
+
+        dept_bucket = department_stats.setdefault(dept_name, {
+            'department': dept_name,
+            'academics': set(),
+            'totalHours': Decimal('0.00'),
+            'pending': 0,
+            'approved': 0,
+            'rejected': 0,
+        })
+        dept_bucket['academics'].add(report.staff_id)
+        dept_bucket['totalHours'] += total
+        status_key = report.status.lower()
+        if status_key == 'pending':
+            dept_bucket['pending'] += 1
+        elif status_key == 'approved':
+            dept_bucket['approved'] += 1
+        elif status_key == 'rejected':
+            dept_bucket['rejected'] += 1
+
+        trend_row = department_trend.setdefault(semester_label, {'semester': semester_label})
+        trend_row[dept_name] = _to_hours(Decimal(str(trend_row.get(dept_name, 0))) + total)
 
     total_work_hours_trend = []
     average_work_hours_by_semester = []
-    for label in sorted(trend):
+    for label in sorted(trend, key=semester_sort_key):
         row = trend[label]
         hours = _to_hours(row['totalWorkHours'])
         staff_count = len(row['staff'])
@@ -467,6 +494,21 @@ def _analytics_payload(qs, year_from, year_to, semester_filter, scope_label):
         'totalWorkHoursTrend': total_work_hours_trend,
         'averageWorkHoursBySemester': average_work_hours_by_semester,
         'statusDistribution': status_distribution,
+        'departmentStats': [
+            {
+                'department': dept,
+                'academics': len(row['academics']),
+                'totalHours': _to_hours(row['totalHours']),
+                'pending': row['pending'],
+                'approved': row['approved'],
+                'rejected': row['rejected'],
+            }
+            for dept, row in sorted(department_stats.items())
+        ],
+        'departmentWorkloadTrend': [
+            department_trend[key]
+            for key in sorted(department_trend.keys(), key=semester_sort_key)
+        ],
         'workloadHoursDistribution': [
             {'department': dept, 'totalWorkHours': _to_hours(hours)}
             for dept, hours in sorted(hours_distribution.items())

--- a/backend/api/view/hos_views.py
+++ b/backend/api/view/hos_views.py
@@ -21,6 +21,8 @@ from api.services.workload_service import (
     _filter_reports_by_range,
     _parse_year_range,
     _reporting_period_label,
+    report_total_hours,
+    semester_sort_key,
 )
 
 ROLE_ALIAS_TO_DB = {
@@ -517,7 +519,7 @@ def hos_visualization(request):
         'total_departments': len({report.snapshot_department_id for report in reports}),
         'total_academics': len({report.staff_id for report in reports}),
         'total_work_hours': float(
-            round(sum(sum(item.allocated_hours for item in report.items.all()) for report in reports), 2)
+            round(sum(report_total_hours(report) for report in reports), 2)
         ),
         'pending_requests': sum(1 for report in reports if report.status == 'PENDING'),
         'approved_requests': sum(1 for report in reports if report.status == 'APPROVED'),
@@ -539,7 +541,7 @@ def hos_visualization(request):
             },
         )
         stats['academics'].add(report.staff_id)
-        stats['total_hours'] += sum(item.allocated_hours for item in report.items.all())
+        stats['total_hours'] += report_total_hours(report)
         if report.status == 'PENDING':
             stats['pending'] += 1
         elif report.status == 'APPROVED':
@@ -568,11 +570,11 @@ def hos_visualization(request):
         trend_row[report.snapshot_department.name] = float(
             round(
                 trend_row.get(report.snapshot_department.name, 0)
-                + sum(item.allocated_hours for item in report.items.all()),
+                + report_total_hours(report),
                 2,
             )
         )
-    workload_trend = [trend_map[key] for key in sorted(trend_map.keys())]
+    workload_trend = [trend_map[key] for key in sorted(trend_map.keys(), key=semester_sort_key)]
 
     return Response(
         {

--- a/backend/api/view/ops_admin_views.py
+++ b/backend/api/view/ops_admin_views.py
@@ -44,6 +44,8 @@ from api.services.workload_service import (
     _filter_reports_by_range,
     _parse_year_range,
     evaluate_mvp_anomaly,
+    report_total_hours,
+    semester_sort_key,
     stale_report_response_payload,
     workload_item_counts_toward_total,
     workload_item_hours_for_totals,
@@ -538,7 +540,7 @@ def _build_visualization_payload(reports_queryset, year_from, year_to, semester_
             'rejected': 0,
         })
         bucket['academics'].add(report.staff_id)
-        total_h = sum((workload_item_hours_for_totals(i) for i in report.items.all()), Decimal('0.00'))
+        total_h = report_total_hours(report)
         bucket['total_hours'] += total_h
         status_key = report.status.lower()
         if status_key == 'pending':
@@ -565,14 +567,14 @@ def _build_visualization_payload(reports_queryset, year_from, year_to, semester_
         label = f"{report.academic_year} {report.semester}"
         entry = trend_map.setdefault(label, {'semester': label})
         dept_name = report.snapshot_department.name
-        hrs = sum((workload_item_hours_for_totals(i) for i in report.items.all()), Decimal('0.00'))
+        hrs = report_total_hours(report)
         entry[dept_name] = float(round(Decimal(str(entry.get(dept_name, 0))) + hrs, 2))
 
-    workload_trend = [trend_map[key] for key in sorted(trend_map.keys())]
+    workload_trend = [trend_map[key] for key in sorted(trend_map.keys(), key=semester_sort_key)]
 
     total_hours_all = Decimal('0.00')
     for report in reports_queryset:
-        total_hours_all += sum((workload_item_hours_for_totals(i) for i in report.items.all()), Decimal('0.00'))
+        total_hours_all += report_total_hours(report)
     academics_union = set()
     pending_total = approved_total = rejected_total = 0
     for report in reports_queryset:

--- a/backend/api/view/supervisor_views.py
+++ b/backend/api/view/supervisor_views.py
@@ -23,6 +23,8 @@ from api.services.workload_service import (
     WORKLOAD_REQUEST_KINDS,
     get_workload_queryset,
     stale_report_response_payload,
+    report_total_hours,
+    semester_sort_key,
     _parse_year_range,
     _filter_reports_by_range,
     _build_semester_label,
@@ -470,18 +472,17 @@ def supervisor_visualization(request):
     rejected_count = qs_submitted.filter(status='REJECTED').count()
 
     # Build ordered (year, semester) buckets
-    SEM_ORDER = {'S1': 0, 'S2': 1, 'FULL_YEAR': 2}
     seen = {}
     for r in reports:
         seen[(r.academic_year, r.semester)] = True
-    ordered_keys = sorted(seen.keys(), key=lambda k: (k[0], SEM_ORDER.get(k[1], 9)))
+    ordered_keys = sorted(seen.keys(), key=semester_sort_key)
 
     # Aggregate total hours and staff count per bucket
     bucket_hours = {}   # key -> total hours (Decimal)
     bucket_staff = {}   # key -> set of staff_ids
     for r in reports:
         key = (r.academic_year, r.semester)
-        total = sum(i.allocated_hours for i in r.items.all())
+        total = report_total_hours(r)
         bucket_hours[key] = bucket_hours.get(key, Decimal('0.00')) + total
         bucket_staff.setdefault(key, set()).add(r.staff_id)
 

--- a/frontend/src/api/hos.ts
+++ b/frontend/src/api/hos.ts
@@ -82,6 +82,15 @@ export type HosAnalyticsPayload = {
   totalWorkHoursTrend: Array<{ period: string; totalWorkHours: number }>;
   averageWorkHoursBySemester: Array<{ period: string; averageWorkHours: number }>;
   statusDistribution: Record<string, number>;
+  departmentStats?: Array<{
+    department: string;
+    academics: number;
+    totalHours: number;
+    pending: number;
+    approved: number;
+    rejected: number;
+  }>;
+  departmentWorkloadTrend?: Array<Record<string, string | number | null>>;
   workloadHoursDistribution: Array<{ department: string; totalWorkHours: number }>;
 };
 

--- a/frontend/src/pages/Academic.tsx
+++ b/frontend/src/pages/Academic.tsx
@@ -699,11 +699,11 @@ const selectedYear = Number(searchYearInput) || currentYear;
 
   const detailItem = useMemo(() => items.find((x) => x.id === detailId) || null, [items, detailId]);
   const myVsDepartmentTrendData = useMemo(
-    () => visualizationData.myVsDepartmentTrend ?? [],
+    () => (visualizationData.myVsDepartmentTrend ?? []).slice(-6),
     [visualizationData]
   );
   const trendChartData = useMemo(
-    () => visualizationData.totalHoursTrend ?? [],
+    () => (visualizationData.totalHoursTrend ?? []).slice(-6),
     [visualizationData]
   );
   const compareTrendDomain = useMemo(
@@ -855,10 +855,6 @@ const selectedYear = Number(searchYearInput) || currentYear;
     }
     const startYear = Math.min(fromYear, toYear);
     const endYear = Math.max(fromYear, toYear);
-    if (endYear - startYear > 2) {
-      setVisualError("Maximum range is 3 years.");
-      return;
-    }
     setAppliedVisualFilters({
       yearFrom: String(startYear),
       yearTo: String(endYear),
@@ -1281,7 +1277,7 @@ const selectedYear = Number(searchYearInput) || currentYear;
                 />
                 {visualError && <div className="mt-3 text-sm font-semibold text-[#dc2626]">{visualError}</div>}
                 <div className="mt-2 text-sm font-semibold text-[#2f4d9c]">
-                  For readability, Visualization supports up to 3 years. Export more data in Export Excel.
+                  For readability, the chart displays the latest 6 semesters in the selected range.
                 </div>
               </div>
               <ReportingPeriodBar periodLabel={reportingPeriodLabel} />

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -121,6 +121,45 @@ type MockRequest = {
   detailSnapshot?: WorkloadDetailSnapshot;
 };
 
+type DepartmentVisualizationStat = {
+  department: string;
+  academics: number;
+  totalHours: number;
+  pending: number;
+  approved: number;
+  rejected: number;
+};
+
+type SchoolVisualizationData = {
+  reportingPeriodLabel: string;
+  scopeLabel: string;
+  summary: {
+    totalDepartments: number;
+    totalAcademics: number;
+    totalWorkHours: number;
+    pendingRequests: number;
+    approvedRequests: number;
+    rejectedRequests: number;
+  };
+  departmentStats: DepartmentVisualizationStat[];
+  trend: Array<Record<string, string | number | null>>;
+};
+
+const EMPTY_SCHOOL_VISUALIZATION: SchoolVisualizationData = {
+  reportingPeriodLabel: "N/A",
+  scopeLabel: "All Departments",
+  summary: {
+    totalDepartments: 0,
+    totalAcademics: 0,
+    totalWorkHours: 0,
+    pendingRequests: 0,
+    approvedRequests: 0,
+    rejectedRequests: 0,
+  },
+  departmentStats: [],
+  trend: [],
+};
+
 type WorkloadListQuery = {
   employeeId: string;
   name: string;
@@ -1257,6 +1296,35 @@ export default function SchoolofOperations() {
     semester: "All",
     department: "All Departments",
   });
+  const [visualizationData, setVisualizationData] = useState<SchoolVisualizationData>(EMPTY_SCHOOL_VISUALIZATION);
+  const [visualizationLoading, setVisualizationLoading] = useState(false);
+
+  async function loadSchoolVisualization(filters = visualFilters) {
+    setVisualizationLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (filters.fromYear) params.set("fromYear", filters.fromYear);
+      if (filters.toYear) params.set("toYear", filters.toYear);
+      params.set("semester", filters.semester);
+      params.set("department", filters.department);
+      const response = await apiJson<{ success: boolean; data: SchoolVisualizationData }>(
+        `/api/school-operations/visualization?${params.toString()}`
+      );
+      setVisualizationData(response.data ?? EMPTY_SCHOOL_VISUALIZATION);
+      setVisualFilterError((prev) => (prev.startsWith("Load failed") ? "" : prev));
+    } catch (error) {
+      setVisualizationData(EMPTY_SCHOOL_VISUALIZATION);
+      const message = error instanceof Error ? error.message : "Could not load visualization.";
+      setVisualFilterError(`Load failed: ${message}`);
+    } finally {
+      setVisualizationLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadSchoolVisualization(visualFilters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visualFilters]);
 
   const availableDepartments: AssignDepartment[] = [
     "Physics",
@@ -1849,34 +1917,14 @@ export default function SchoolofOperations() {
   }, [adminPage, adminTotalPages]);
 
   const departmentStats = useMemo(
-    () => [
-      {
-        department: "Computer Science & Software Engineering",
-        totalHours: 430,
-        academics: 27,
-        pending: 17,
-        approved: 8,
-        rejected: 2,
-      },
-      {
-        department: "Mathematics & Statistics",
-        totalHours: 318,
-        academics: 19,
-        pending: 7,
-        approved: 10,
-        rejected: 2,
-      },
-      {
-        department: "Physics",
-        totalHours: 264,
-        academics: 14,
-        pending: 5,
-        approved: 7,
-        rejected: 2,
-      },
-    ],
-    []
+    () => visualizationData.departmentStats ?? [],
+    [visualizationData]
   );
+  const visualDepartmentOptions = useMemo(() => {
+    const names = new Set<string>(ACADEMIC_IMPORT_DEPARTMENTS);
+    departmentStats.forEach((item) => names.add(item.department));
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [departmentStats]);
   const filteredDepartmentStats = useMemo(() => {
     if (visualFilters.department === "All Departments") return departmentStats;
     return departmentStats.filter((item) => item.department === visualFilters.department);
@@ -1935,32 +1983,22 @@ export default function SchoolofOperations() {
     [filteredDepartmentStats]
   );
 
-  const workloadTrendBySemester = useMemo(() => {
-    const startYear = currentYear - 5;
-    const endYear = currentYear + 5;
-    const currentMonth = new Date().getMonth();
-    const hasReachedS2 = currentMonth >= 6;
-    const rows: Array<Record<string, string | number | null>> = [];
-    for (let year = startYear; year <= endYear; year += 1) {
-      const offset = year - startYear;
-      rows.push({
-        semester: `${year} S1`,
-        "Computer Science & Software Engineering": 178 + offset * 8,
-        "Mathematics & Statistics": 128 + offset * 6,
-        Physics: 104 + offset * 5,
-      });
-      rows.push({
-        semester: `${year} S2`,
-        "Computer Science & Software Engineering":
-          year === currentYear && !hasReachedS2 ? null : 186 + offset * 9,
-        "Mathematics & Statistics": year === currentYear && !hasReachedS2 ? null : 136 + offset * 7,
-        Physics: year === currentYear && !hasReachedS2 ? null : 111 + offset * 6,
-      });
-    }
-    return rows;
-  }, [currentYear]);
+  const workloadTrendBySemester = useMemo(
+    () => visualizationData.trend ?? [],
+    [visualizationData]
+  );
 
   const schoolSummary = useMemo(() => {
+    if (visualFilters.department === "All Departments") {
+      return {
+        totalDepartments: visualizationData.summary.totalDepartments,
+        totalAcademics: visualizationData.summary.totalAcademics,
+        totalWorkHours: Number(visualizationData.summary.totalWorkHours.toFixed(1)),
+        pendingRequests: visualizationData.summary.pendingRequests,
+        approvedRequests: visualizationData.summary.approvedRequests,
+        rejectedRequests: visualizationData.summary.rejectedRequests,
+      };
+    }
     const totalAcademics = filteredDepartmentStats.reduce((sum, item) => sum + item.academics, 0);
     const totalWorkHours = filteredDepartmentStats.reduce((sum, item) => sum + item.totalHours, 0);
     const pendingRequests = filteredDepartmentStats.reduce((sum, item) => sum + item.pending, 0);
@@ -1974,7 +2012,7 @@ export default function SchoolofOperations() {
       approvedRequests,
       rejectedRequests,
     };
-  }, [filteredDepartmentStats]);
+  }, [filteredDepartmentStats, visualizationData, visualFilters.department]);
   const workloadPerAcademicByDepartment = useMemo(
     () =>
       filteredDepartmentStats.map((item) => ({
@@ -2011,6 +2049,7 @@ export default function SchoolofOperations() {
     });
   }, [workloadTrendBySemester, visualFilters, currentYear]);
   const reportingPeriodLabel = useMemo(() => {
+    if (visualizationData.reportingPeriodLabel) return visualizationData.reportingPeriodLabel;
     const yearLabel =
       visualFilters.fromYear === visualFilters.toYear
         ? visualFilters.fromYear
@@ -2019,10 +2058,10 @@ export default function SchoolofOperations() {
       return `${yearLabel} All Semesters`;
     }
     return `${yearLabel} ${visualFilters.semester}`;
-  }, [visualFilters]);
+  }, [visualFilters, visualizationData]);
   const scopeLabel = useMemo(
-    () => (visualFilters.department === "All Departments" ? "All Departments" : visualFilters.department),
-    [visualFilters.department]
+    () => visualizationData.scopeLabel || (visualFilters.department === "All Departments" ? "All Departments" : visualFilters.department),
+    [visualizationData.scopeLabel, visualFilters.department]
   );
   const departmentColorMap: Record<string, string> = {
     "Computer Science & Software Engineering": "#1f3b86",
@@ -2047,12 +2086,6 @@ export default function SchoolofOperations() {
     }
     const startYear = Math.min(fromYear, toYear);
     const endYear = Math.max(fromYear, toYear);
-    const yearSpan = endYear - startYear;
-    const maxYearSpan = 2;
-    if (yearSpan > maxYearSpan) {
-      setVisualFilterError("Maximum range is 3 years.");
-      return;
-    }
     setVisualFilterError("");
     setVisualFilters({
       fromYear: String(startYear),
@@ -4547,9 +4580,9 @@ export default function SchoolofOperations() {
                       className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
                     >
                       <option value="All Departments">All Departments</option>
-                      {departmentStats.map((item) => (
-                        <option key={item.department} value={item.department}>
-                          {item.department}
+                      {visualDepartmentOptions.map((department) => (
+                        <option key={department} value={department}>
+                          {department}
                         </option>
                       ))}
                     </select>
@@ -4566,11 +4599,13 @@ export default function SchoolofOperations() {
                   </div>
                 </div>
                 <div className="mt-3 text-sm font-semibold text-[#2f4d9c]">
-                  For readability, the dashboard displays up to 3 full academic years at a time. You can export more
-                  data in the Export Excel tab.
+                  For readability, the chart displays the latest 6 semesters in the selected range.
                 </div>
                 {visualFilterError && (
                   <div className="mt-3 text-sm font-semibold text-[#dc2626]">{visualFilterError}</div>
+                )}
+                {visualizationLoading && (
+                  <div className="mt-3 text-sm font-semibold text-slate-500">Loading visualization...</div>
                 )}
               </div>
               <div className="mt-3">
@@ -4916,9 +4951,9 @@ export default function SchoolofOperations() {
                     className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
                   >
                     <option value="All Departments">All Departments</option>
-                    {departmentStats.map((item) => (
-                      <option key={`export-dept-${item.department}`} value={item.department}>
-                        {item.department}
+                    {visualDepartmentOptions.map((department) => (
+                      <option key={`export-dept-${department}`} value={department}>
+                        {department}
                       </option>
                     ))}
                   </select>

--- a/frontend/src/pages/HeadofSchool.tsx
+++ b/frontend/src/pages/HeadofSchool.tsx
@@ -593,17 +593,34 @@ export default function HeadofSchool() {
   }, [adminSearchFilters, assignablePeople]);
 
   const departmentStats = useMemo(
-    () =>
-      (analyticsData?.workloadHoursDistribution ?? []).map((item) => ({
+    () => {
+      const stats = analyticsData?.departmentStats;
+      if (stats?.length) {
+        return stats.map((item) => ({
+          department: item.department,
+          totalHours: Number(item.totalHours) || 0,
+          academics: Number(item.academics) || 0,
+          pending: Number(item.pending) || 0,
+          approved: Number(item.approved) || 0,
+          rejected: Number(item.rejected) || 0,
+        }));
+      }
+      return (analyticsData?.workloadHoursDistribution ?? []).map((item) => ({
         department: item.department,
         totalHours: Number(item.totalWorkHours) || 0,
         academics: 0,
         pending: 0,
         approved: 0,
         rejected: 0,
-      })),
+      }));
+    },
     [analyticsData]
   );
+  const visualDepartmentOptions = useMemo(() => {
+    const names = new Set<string>(["Physics", "Mathematics & Statistics", "Computer Science & Software Engineering"]);
+    departmentStats.forEach((item) => names.add(item.department));
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [departmentStats]);
   const filteredDepartmentStats = useMemo(() => {
     if (visualFilters.department === "All Departments") return departmentStats;
     return departmentStats.filter((item) => item.department === visualFilters.department);
@@ -663,11 +680,14 @@ export default function HeadofSchool() {
   );
 
   const workloadTrendBySemester = useMemo(
-    () =>
-      (analyticsData?.totalWorkHoursTrend ?? []).map((item) => ({
+    () => {
+      const departmentTrend = analyticsData?.departmentWorkloadTrend;
+      if (departmentTrend?.length) return departmentTrend;
+      return (analyticsData?.totalWorkHoursTrend ?? []).map((item) => ({
         semester: item.period,
         "Total Work Hours": item.totalWorkHours,
-      })),
+      }));
+    },
     [analyticsData]
   );
 
@@ -755,12 +775,6 @@ export default function HeadofSchool() {
     }
     const startYear = Math.min(fromYear, toYear);
     const endYear = Math.max(fromYear, toYear);
-    const yearSpan = endYear - startYear;
-    const maxYearSpan = 2;
-    if (yearSpan > maxYearSpan) {
-      setVisualFilterError("Maximum range is 3 years.");
-      return;
-    }
     setVisualFilterError("");
     setVisualFilters({
       fromYear: String(startYear),
@@ -2033,9 +2047,9 @@ export default function HeadofSchool() {
                       className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
                     >
                       <option value="All Departments">All Departments</option>
-                      {departmentStats.map((item) => (
-                        <option key={item.department} value={item.department}>
-                          {item.department}
+                      {visualDepartmentOptions.map((department) => (
+                        <option key={department} value={department}>
+                          {department}
                         </option>
                       ))}
                     </select>
@@ -2315,25 +2329,50 @@ export default function HeadofSchool() {
                           align="right"
                           wrapperStyle={legendStyle}
                         />
-                        <Line
-                          type="monotone"
-                          dataKey="Total Work Hours"
-                          stroke="#1f3b86"
-                          strokeWidth={2}
-                          dot={(props: any) => {
-                            const isCurrentSemester = props?.payload?.semester === currentSemesterLabel;
-                            return (
-                              <circle
-                                cx={props.cx}
-                                cy={props.cy}
-                                r={isCurrentSemester ? 6 : 3}
-                                fill="#1f3b86"
-                                stroke="#ffffff"
-                                strokeWidth={isCurrentSemester ? 2 : 1}
-                              />
-                            );
-                          }}
-                        />
+                        {filteredDepartmentStats.length > 0 ? (
+                          filteredDepartmentStats.map((item) => (
+                            <Line
+                              key={item.department}
+                              type="monotone"
+                              dataKey={item.department}
+                              stroke={departmentColorMap[item.department] || "#1e3a8a"}
+                              strokeWidth={2}
+                              dot={(props: any) => {
+                                const isCurrentSemester = props?.payload?.semester === currentSemesterLabel;
+                                return (
+                                  <circle
+                                    cx={props.cx}
+                                    cy={props.cy}
+                                    r={isCurrentSemester ? 6 : 3}
+                                    fill={departmentColorMap[item.department] || "#1e3a8a"}
+                                    stroke="#ffffff"
+                                    strokeWidth={isCurrentSemester ? 2 : 1}
+                                  />
+                                );
+                              }}
+                            />
+                          ))
+                        ) : (
+                          <Line
+                            type="monotone"
+                            dataKey="Total Work Hours"
+                            stroke="#1f3b86"
+                            strokeWidth={2}
+                            dot={(props: any) => {
+                              const isCurrentSemester = props?.payload?.semester === currentSemesterLabel;
+                              return (
+                                <circle
+                                  cx={props.cx}
+                                  cy={props.cy}
+                                  r={isCurrentSemester ? 6 : 3}
+                                  fill="#1f3b86"
+                                  stroke="#ffffff"
+                                  strokeWidth={isCurrentSemester ? 2 : 1}
+                                />
+                              );
+                            }}
+                          />
+                        )}
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -2394,9 +2433,9 @@ export default function HeadofSchool() {
                     className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
                   >
                     <option value="All Departments">All Departments</option>
-                    {departmentStats.map((item) => (
-                      <option key={`export-dept-${item.department}`} value={item.department}>
-                        {item.department}
+                    {visualDepartmentOptions.map((department) => (
+                      <option key={`export-dept-${department}`} value={department}>
+                        {department}
                       </option>
                     ))}
                   </select>

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -583,7 +583,7 @@ export default function Supervisor() {
       (visualizationData.averageWorkHoursBySemester ?? []).map((item) => ({
         semester: item.period,
         averageHours: item.averageWorkHours,
-      })),
+      })).slice(-6),
     [visualizationData]
   );
   const trendChartData = useMemo(
@@ -591,7 +591,7 @@ export default function Supervisor() {
       (visualizationData.totalWorkHoursTrend ?? []).map((item) => ({
         semester: item.period,
         totalHours: item.totalWorkHours,
-      })),
+      })).slice(-6),
     [visualizationData]
   );
   const averageHoursDomain = useMemo(
@@ -645,10 +645,6 @@ export default function Supervisor() {
     }
     const startYear = Math.min(fromYear, toYear);
     const endYear = Math.max(fromYear, toYear);
-    if (endYear - startYear > 2) {
-      setVisualError("Maximum range is 3 years.");
-      return;
-    }
     setAppliedVisualFilters({
       yearFrom: String(startYear),
       yearTo: String(endYear),
@@ -1254,7 +1250,7 @@ export default function Supervisor() {
                 </div>
                 {visualError && <div className="mt-3 text-sm font-semibold text-[#dc2626]">{visualError}</div>}
                 <div className="mt-2 text-sm font-semibold text-[#2f4d9c]">
-                  For readability, Visualization supports up to 3 years. Export more data in Export Excel.
+                  For readability, the chart displays the latest 6 semesters in the selected range.
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- replace School Ops visualization mock data with backend data from Postgres
- add shared total-hour helpers so visualization includes Research (residual)
- extend HoS analytics with department stats and department workload trend
- allow wider year ranges while rendering only the latest 6 chart semesters
- add regression tests that seed 7 semesters of workload data

## Verification
- docker compose exec -T backend python manage.py check
- docker compose exec -T backend python manage.py test api.tests.TestVisualizationRealData
- docker compose exec -T backend python manage.py test api.tests.TestAcademicVisualization api.tests.TestVisualizationRealData api.tests.TestHoSContractEndpoints.test_hos_visualization_contract_shape
- docker compose exec -T frontend npm run build (passes with existing lint warnings)