### PR TITLE
Fix filter search and export data flow

### DIFF
--- a/frontend/src/pages/Academic.tsx
+++ b/frontend/src/pages/Academic.tsx
@@ -167,6 +167,13 @@ type AcademicWorkloadListResponse = {
   };
 };
 
+type AcademicSearchFilters = {
+  status: "all" | "pending" | "approved" | "rejected";
+  confirmation: "" | "confirmed" | "unconfirmed";
+  year: string;
+  semester: "" | "S1" | "S2";
+};
+
 type AcademicWorkloadDetailResponse = AcademicWorkloadRowResponse & {
   actualTeachingRatio?: number | null;
   employmentType?: string | null;
@@ -520,12 +527,7 @@ export default function Academic() {
   );
   const [searchYearInput, setSearchYearInput] = useState("");
   const [searchSemesterInput, setSearchSemesterInput] = useState<"" | "S1" | "S2">("");
-  const [searchFilters, setSearchFilters] = useState<{
-    status: "all" | "pending" | "approved" | "rejected";
-    confirmation: "" | "confirmed" | "unconfirmed";
-    year: string;
-    semester: "" | "S1" | "S2";
-  }>({
+  const [searchFilters, setSearchFilters] = useState<AcademicSearchFilters>({
     status: "all",
     confirmation: "",
     year: "",
@@ -542,7 +544,7 @@ export default function Academic() {
   const [visualSemesterInput, setVisualSemesterInput] = useState<"All" | "S1" | "S2">("All");
   const [visualError, setVisualError] = useState("");
   const [visualizationLoading, setVisualizationLoading] = useState(false);
-  const [_appliedVisualFilters, setAppliedVisualFilters] = useState({
+  const [, setAppliedVisualFilters] = useState({
     yearFrom: "",
     yearTo: "",
     semester: "All" as "All" | "S1" | "S2",
@@ -572,11 +574,17 @@ const selectedYear = Number(searchYearInput) || currentYear;
     [selectedYear]
   );
 
-  const loadAcademicWorkloads = useCallback(async (options?: { silent?: boolean }) => {
+  const loadAcademicWorkloads = useCallback(async (options?: { silent?: boolean; filters?: AcademicSearchFilters }) => {
     if (!options?.silent) setLoadingItems(true);
     setPageError("");
     try {
-      const response = await apiJson<AcademicWorkloadListResponse>("/api/academic/workloads/");
+      const params = new URLSearchParams({ page_size: "100" });
+      const filters = options?.filters;
+      if (filters?.status && filters.status !== "all") params.set("status", filters.status);
+      if (filters?.confirmation) params.set("confirmation", filters.confirmation);
+      if (filters?.year) params.set("year", filters.year);
+      if (filters?.semester) params.set("semester", filters.semester);
+      const response = await apiJson<AcademicWorkloadListResponse>(`/api/academic/workloads/?${params.toString()}`);
       setItems((response.items ?? []).map((row) => mapAcademicRowToItem(row, user.department)));
     } catch (error) {
       if (!isAbortError(error)) {
@@ -644,7 +652,7 @@ const selectedYear = Number(searchYearInput) || currentYear;
   useEffect(() => {
     const refreshLatestWorkloads = () => {
       if (document.visibilityState === "visible") {
-        void loadAcademicWorkloads({ silent: true });
+        void loadAcademicWorkloads({ silent: true, filters: searchFilters });
       }
     };
 
@@ -656,41 +664,9 @@ const selectedYear = Number(searchYearInput) || currentYear;
       document.removeEventListener("visibilitychange", refreshLatestWorkloads);
       window.clearInterval(intervalId);
     };
-  }, [loadAcademicWorkloads]);
+  }, [loadAcademicWorkloads, searchFilters]);
 
-  const filteredItems = useMemo(() => {
-    let next = searchFilters.status === "all" ? items : items.filter((x) => x.status === searchFilters.status);
-
-    if (searchFilters.confirmation) {
-      next = next.filter((x) => x.confirmation === searchFilters.confirmation);
-    }
-
-    const selectedYearNumber = Number(searchFilters.year);
-    if (searchFilters.year && Number.isFinite(selectedYearNumber)) {
-      next = next.filter((x) => {
-        const pushedAt = academicPushedAt(x);
-        if (!pushedAt) return false;
-        const submitted = parseDateTime(pushedAt);
-        if (Number.isNaN(submitted.getTime())) return false;
-
-        if (searchFilters.semester === "S1") {
-          const s1Start = new Date(selectedYearNumber, 0, 1);
-          const s1End = new Date(selectedYearNumber, 6, 1);
-          return submitted >= s1Start && submitted < s1End;
-        }
-
-        if (searchFilters.semester === "S2") {
-          const s2Start = new Date(selectedYearNumber, 6, 1);
-          const s2End = new Date(selectedYearNumber + 1, 0, 1);
-          return submitted >= s2Start && submitted < s2End;
-        }
-
-        return submitted.getFullYear() === selectedYearNumber;
-      });
-    }
-
-    return next;
-  }, [items, searchFilters]);
+  const filteredItems = items;
   const totalPages = Math.max(1, Math.ceil(filteredItems.length / pageSize));
   const pageItems = useMemo(() => {
     const start = (page - 1) * pageSize;
@@ -836,13 +812,15 @@ const selectedYear = Number(searchYearInput) || currentYear;
   }
 
   function handleSearch() {
-    setSearchFilters({
+    const nextFilters: AcademicSearchFilters = {
       status: filter,
       confirmation: confirmationFilter,
       year: searchYearInput,
       semester: searchSemesterInput,
-    });
+    };
+    setSearchFilters(nextFilters);
     setPage(1);
+    void loadAcademicWorkloads({ filters: nextFilters });
   }
 
   async function handleApplyVisualizationFilter() {

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -121,45 +121,6 @@ type MockRequest = {
   detailSnapshot?: WorkloadDetailSnapshot;
 };
 
-type DepartmentVisualizationStat = {
-  department: string;
-  academics: number;
-  totalHours: number;
-  pending: number;
-  approved: number;
-  rejected: number;
-};
-
-type SchoolVisualizationData = {
-  reportingPeriodLabel: string;
-  scopeLabel: string;
-  summary: {
-    totalDepartments: number;
-    totalAcademics: number;
-    totalWorkHours: number;
-    pendingRequests: number;
-    approvedRequests: number;
-    rejectedRequests: number;
-  };
-  departmentStats: DepartmentVisualizationStat[];
-  trend: Array<Record<string, string | number | null>>;
-};
-
-const EMPTY_SCHOOL_VISUALIZATION: SchoolVisualizationData = {
-  reportingPeriodLabel: "N/A",
-  scopeLabel: "All Departments",
-  summary: {
-    totalDepartments: 0,
-    totalAcademics: 0,
-    totalWorkHours: 0,
-    pendingRequests: 0,
-    approvedRequests: 0,
-    rejectedRequests: 0,
-  },
-  departmentStats: [],
-  trend: [],
-};
-
 type WorkloadListQuery = {
   employeeId: string;
   name: string;
@@ -1313,37 +1274,28 @@ export default function SchoolofOperations() {
     department: "All Departments",
   });
   const [adminVisualization, setAdminVisualization] = useState<AdminVisualizationPayload | null>(null);
-
-  async function loadAdminVisualization(filters = visualFilters) {
-    const params = new URLSearchParams();
-    if (filters.fromYear) params.set("year_from", filters.fromYear);
-    if (filters.toYear) params.set("year_to", filters.toYear);
-    params.set("semester", filters.semester);
-    if (filters.department !== "All Departments") params.set("department", filters.department);
-    const response = await apiJson<{
-      success: boolean;
-      data: AdminVisualizationPayload;
-    }>(`/api/school-operations/visualization?${params.toString()}`);
-    if (response.success) {
-      setAdminVisualization(response.data);
-  const [visualizationData, setVisualizationData] = useState<SchoolVisualizationData>(EMPTY_SCHOOL_VISUALIZATION);
   const [visualizationLoading, setVisualizationLoading] = useState(false);
 
-  async function loadSchoolVisualization(filters = visualFilters) {
+  async function loadAdminVisualization(filters = visualFilters) {
     setVisualizationLoading(true);
     try {
       const params = new URLSearchParams();
-      if (filters.fromYear) params.set("fromYear", filters.fromYear);
-      if (filters.toYear) params.set("toYear", filters.toYear);
+      if (filters.fromYear) params.set("year_from", filters.fromYear);
+      if (filters.toYear) params.set("year_to", filters.toYear);
       params.set("semester", filters.semester);
-      params.set("department", filters.department);
-      const response = await apiJson<{ success: boolean; data: SchoolVisualizationData }>(
+      if (filters.department !== "All Departments") params.set("department", filters.department);
+      const response = await apiJson<{
+        success: boolean;
+        data: AdminVisualizationPayload;
+      }>(
         `/api/school-operations/visualization?${params.toString()}`
       );
-      setVisualizationData(response.data ?? EMPTY_SCHOOL_VISUALIZATION);
+      if (response.success) {
+        setAdminVisualization(response.data);
+      }
       setVisualFilterError((prev) => (prev.startsWith("Load failed") ? "" : prev));
     } catch (error) {
-      setVisualizationData(EMPTY_SCHOOL_VISUALIZATION);
+      setAdminVisualization(null);
       const message = error instanceof Error ? error.message : "Could not load visualization.";
       setVisualFilterError(`Load failed: ${message}`);
     } finally {
@@ -2051,22 +2003,12 @@ export default function SchoolofOperations() {
   );
 
   const schoolSummary = useMemo(() => {
-    if (visualFilters.department === "All Departments") {
-      return {
-        totalDepartments: visualizationData.summary.totalDepartments,
-        totalAcademics: visualizationData.summary.totalAcademics,
-        totalWorkHours: Number(visualizationData.summary.totalWorkHours.toFixed(1)),
-        pendingRequests: visualizationData.summary.pendingRequests,
-        approvedRequests: visualizationData.summary.approvedRequests,
-        rejectedRequests: visualizationData.summary.rejectedRequests,
-      };
-    }
     const totalAcademics = filteredDepartmentStats.reduce((sum, item) => sum + item.academics, 0);
     const totalWorkHours = filteredDepartmentStats.reduce((sum, item) => sum + item.totalHours, 0);
     const pendingRequests = filteredDepartmentStats.reduce((sum, item) => sum + item.pending, 0);
     const approvedRequests = filteredDepartmentStats.reduce((sum, item) => sum + item.approved, 0);
     const rejectedRequests = filteredDepartmentStats.reduce((sum, item) => sum + item.rejected, 0);
-    return {
+    const fallbackSummary = {
       totalDepartments: filteredDepartmentStats.length,
       totalAcademics,
       totalWorkHours: Number(totalWorkHours.toFixed(1)),
@@ -2074,7 +2016,20 @@ export default function SchoolofOperations() {
       approvedRequests,
       rejectedRequests,
     };
-  }, [filteredDepartmentStats, visualizationData, visualFilters.department]);
+
+    if (visualFilters.department === "All Departments") {
+      const summary = adminVisualization?.summary;
+      return {
+        totalDepartments: Number(summary?.totalDepartments ?? fallbackSummary.totalDepartments),
+        totalAcademics: Number(summary?.totalAcademics ?? fallbackSummary.totalAcademics),
+        totalWorkHours: Number(Number(summary?.totalWorkHours ?? fallbackSummary.totalWorkHours).toFixed(1)),
+        pendingRequests: Number(summary?.pendingRequests ?? fallbackSummary.pendingRequests),
+        approvedRequests: Number(summary?.approvedRequests ?? fallbackSummary.approvedRequests),
+        rejectedRequests: Number(summary?.rejectedRequests ?? fallbackSummary.rejectedRequests),
+      };
+    }
+    return fallbackSummary;
+  }, [adminVisualization, filteredDepartmentStats, visualFilters.department]);
   const workloadPerAcademicByDepartment = useMemo(
     () =>
       filteredDepartmentStats.map((item) => ({

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -54,7 +54,7 @@ import WorkloadDetailModal, {
   type WorkloadDetailField,
   type WorkloadDetailNoteSection,
 } from "../components/common/WorkloadDetailModal";
-import { apiJson } from "../api/client";
+import { apiJson, downloadApiFile } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import { profileFromAuth } from "../auth/profileFromAuth";
 
@@ -133,6 +133,38 @@ type OpsPeriodInfo = {
   year: number | null;
   semester: "" | "S1" | "S2" | "FULL_YEAR" | "ALL";
   label: string;
+};
+
+type AdminDepartmentStat = {
+  department: string;
+  academics: number;
+  totalHours: number;
+  pending: number;
+  approved: number;
+  rejected: number;
+};
+
+type AdminVisualizationPayload = {
+  reportingPeriodLabel?: string;
+  scopeLabel?: string;
+  summary?: {
+    totalDepartments?: number;
+    totalAcademics?: number;
+    totalWorkHours?: number;
+    pendingRequests?: number;
+    approvedRequests?: number;
+    rejectedRequests?: number;
+  };
+  departmentStats?: Array<{
+    department: string;
+    academics: number;
+    total_hours?: number;
+    totalHours?: number;
+    pending: number;
+    approved: number;
+    rejected: number;
+  }>;
+  trend?: Array<Record<string, string | number | null>>;
 };
 
 type BreakdownCategory = "Teaching" | "Assigned Roles" | "HDR" | "Service" | "Research (residual)";
@@ -777,22 +809,6 @@ function rowMatchesWorkloadFailedTab(
   return false;
 }
 
-/** Last name, first name, or full name (substring or order-independent tokens; commas as spaces). */
-function workloadNameSearchMatches(recordName: string, queryRaw: string): boolean {
-  const q = queryRaw.trim().toLowerCase();
-  if (!q) return true;
-  const norm = recordName
-    .toLowerCase()
-    .replace(/,/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!norm) return false;
-  if (norm.includes(q)) return true;
-  const qTokens = q.split(/\s+/).filter(Boolean);
-  const parts = norm.split(" ").filter(Boolean);
-  return qTokens.every((t) => parts.some((p) => p.includes(t)));
-}
-
 function shortDepartmentName(department: string) {
   if (department === "Computer Science & Software Engineering") return "CS&SE";
   if (department === "Mathematics & Statistics") return "Math&Stats";
@@ -1257,6 +1273,27 @@ export default function SchoolofOperations() {
     semester: "All",
     department: "All Departments",
   });
+  const [adminVisualization, setAdminVisualization] = useState<AdminVisualizationPayload | null>(null);
+
+  async function loadAdminVisualization(filters = visualFilters) {
+    const params = new URLSearchParams();
+    if (filters.fromYear) params.set("year_from", filters.fromYear);
+    if (filters.toYear) params.set("year_to", filters.toYear);
+    params.set("semester", filters.semester);
+    if (filters.department !== "All Departments") params.set("department", filters.department);
+    const response = await apiJson<{
+      success: boolean;
+      data: AdminVisualizationPayload;
+    }>(`/api/school-operations/visualization?${params.toString()}`);
+    if (response.success) {
+      setAdminVisualization(response.data);
+    }
+  }
+
+  useEffect(() => {
+    void loadAdminVisualization();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const availableDepartments: AssignDepartment[] = [
     "Physics",
@@ -1811,6 +1848,30 @@ export default function SchoolofOperations() {
     XLSX.writeFile(wb, `workload_${statusFilter}_${stamp}.xlsx`);
   }
 
+  async function handleSchoolExportExcel() {
+    const params = new URLSearchParams();
+    if (exportYearFromInput.trim()) params.set("year_from", exportYearFromInput.trim());
+    if (exportYearToInput.trim()) params.set("year_to", exportYearToInput.trim());
+    params.set("semester", exportSemesterInput);
+    if (exportDepartmentInput !== "All Departments") params.set("department", exportDepartmentInput);
+    try {
+      await downloadApiFile(`/api/school-operations/export?${params.toString()}`, "School_Workload_History.xlsx");
+      setPopup({
+        open: true,
+        title: "Export ready",
+        message: "School workload export downloaded.",
+        status: "approved",
+      });
+    } catch (error) {
+      setPopup({
+        open: true,
+        title: "Export failed",
+        message: error instanceof Error ? error.message : "Unable to export school workload data.",
+        status: "rejected",
+      });
+    }
+  }
+
   const adminSearchResults = useMemo(() => {
     const hasFilter = Object.values(adminSearchFilters).some((value) => value);
     if (!hasFilter) return assignablePeople;
@@ -1848,34 +1909,17 @@ export default function SchoolofOperations() {
     }
   }, [adminPage, adminTotalPages]);
 
-  const departmentStats = useMemo(
-    () => [
-      {
-        department: "Computer Science & Software Engineering",
-        totalHours: 430,
-        academics: 27,
-        pending: 17,
-        approved: 8,
-        rejected: 2,
-      },
-      {
-        department: "Mathematics & Statistics",
-        totalHours: 318,
-        academics: 19,
-        pending: 7,
-        approved: 10,
-        rejected: 2,
-      },
-      {
-        department: "Physics",
-        totalHours: 264,
-        academics: 14,
-        pending: 5,
-        approved: 7,
-        rejected: 2,
-      },
-    ],
-    []
+  const departmentStats = useMemo<AdminDepartmentStat[]>(
+    () =>
+      (adminVisualization?.departmentStats ?? []).map((item) => ({
+        department: item.department,
+        totalHours: Number(item.totalHours ?? item.total_hours ?? 0),
+        academics: Number(item.academics ?? 0),
+        pending: Number(item.pending ?? 0),
+        approved: Number(item.approved ?? 0),
+        rejected: Number(item.rejected ?? 0),
+      })),
+    [adminVisualization]
   );
   const filteredDepartmentStats = useMemo(() => {
     if (visualFilters.department === "All Departments") return departmentStats;
@@ -1935,30 +1979,10 @@ export default function SchoolofOperations() {
     [filteredDepartmentStats]
   );
 
-  const workloadTrendBySemester = useMemo(() => {
-    const startYear = currentYear - 5;
-    const endYear = currentYear + 5;
-    const currentMonth = new Date().getMonth();
-    const hasReachedS2 = currentMonth >= 6;
-    const rows: Array<Record<string, string | number | null>> = [];
-    for (let year = startYear; year <= endYear; year += 1) {
-      const offset = year - startYear;
-      rows.push({
-        semester: `${year} S1`,
-        "Computer Science & Software Engineering": 178 + offset * 8,
-        "Mathematics & Statistics": 128 + offset * 6,
-        Physics: 104 + offset * 5,
-      });
-      rows.push({
-        semester: `${year} S2`,
-        "Computer Science & Software Engineering":
-          year === currentYear && !hasReachedS2 ? null : 186 + offset * 9,
-        "Mathematics & Statistics": year === currentYear && !hasReachedS2 ? null : 136 + offset * 7,
-        Physics: year === currentYear && !hasReachedS2 ? null : 111 + offset * 6,
-      });
-    }
-    return rows;
-  }, [currentYear]);
+  const workloadTrendBySemester = useMemo(
+    () => adminVisualization?.trend ?? [],
+    [adminVisualization]
+  );
 
   const schoolSummary = useMemo(() => {
     const totalAcademics = filteredDepartmentStats.reduce((sum, item) => sum + item.academics, 0);
@@ -2011,6 +2035,7 @@ export default function SchoolofOperations() {
     });
   }, [workloadTrendBySemester, visualFilters, currentYear]);
   const reportingPeriodLabel = useMemo(() => {
+    if (adminVisualization?.reportingPeriodLabel) return adminVisualization.reportingPeriodLabel;
     const yearLabel =
       visualFilters.fromYear === visualFilters.toYear
         ? visualFilters.fromYear
@@ -2019,10 +2044,10 @@ export default function SchoolofOperations() {
       return `${yearLabel} All Semesters`;
     }
     return `${yearLabel} ${visualFilters.semester}`;
-  }, [visualFilters]);
+  }, [adminVisualization, visualFilters]);
   const scopeLabel = useMemo(
-    () => (visualFilters.department === "All Departments" ? "All Departments" : visualFilters.department),
-    [visualFilters.department]
+    () => adminVisualization?.scopeLabel || (visualFilters.department === "All Departments" ? "All Departments" : visualFilters.department),
+    [adminVisualization, visualFilters.department]
   );
   const departmentColorMap: Record<string, string> = {
     "Computer Science & Software Engineering": "#1f3b86",
@@ -2038,7 +2063,7 @@ export default function SchoolofOperations() {
   };
   const currentSemesterLabel = `${currentYear} ${currentSemester}`;
 
-  function handleApplyVisualizationFilter() {
+  async function handleApplyVisualizationFilter() {
     const fromYear = Number(visualYearFromInput);
     const toYear = Number(visualYearToInput);
     if (!Number.isFinite(fromYear) || !Number.isFinite(toYear)) {
@@ -2054,12 +2079,14 @@ export default function SchoolofOperations() {
       return;
     }
     setVisualFilterError("");
-    setVisualFilters({
+    const nextFilters = {
       fromYear: String(startYear),
       toYear: String(endYear),
       semester: visualSemesterInput,
       department: visualDepartmentInput,
-    });
+    };
+    setVisualFilters(nextFilters);
+    await loadAdminVisualization(nextFilters);
   }
   const legendStyle = { fontFamily: "Inter, Arial, sans-serif", fontSize: 12 };
 
@@ -2313,13 +2340,20 @@ export default function SchoolofOperations() {
       });
   }
 
-  function handleAdminSearch() {
-    setAdminSearchFilters({
+  async function handleAdminSearch() {
+    const nextFilters = {
       firstName: adminSearchFirstNameInput.trim().toLowerCase(),
       lastName: adminSearchLastNameInput.trim().toLowerCase(),
       staffId: adminSearchStaffIdInput.trim().toLowerCase(),
-    });
+    };
+    setAdminSearchFilters(nextFilters);
     setAdminPage(1);
+    const params = new URLSearchParams({ page: "1", page_size: "100" });
+    if (nextFilters.firstName) params.set("first_name", nextFilters.firstName);
+    if (nextFilters.lastName) params.set("last_name", nextFilters.lastName);
+    if (nextFilters.staffId) params.set("staff_id", nextFilters.staffId);
+    const response = await apiJson<StaffDirectoryResponse>(`/api/school-operations/staff?${params.toString()}`);
+    setAssignablePeople((response.data?.items ?? []).map(mapStaffRowToAssignablePerson));
   }
 
   function handlePersonDepartmentChange(personId: number, nextDepartment: string) {
@@ -4927,6 +4961,7 @@ export default function SchoolofOperations() {
                 <div className="flex items-end">
                   <button
                     type="button"
+                    onClick={handleSchoolExportExcel}
                     className="w-full rounded bg-[#2f4d9c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#264183]"
                   >
                     Export Excel

--- a/frontend/src/pages/HeadofSchool.tsx
+++ b/frontend/src/pages/HeadofSchool.tsx
@@ -51,6 +51,16 @@ import ThemedNoticeModal, { SUPERSEDED_RECORD_MESSAGE } from "../components/comm
 import WorkHoursBadge from "../components/common/WorkHoursBadge";
 import WorkloadApprovalModal from "../components/common/WorkloadApprovalModal";
 
+type HosStatusFilter = "all" | "pending" | "approved" | "rejected";
+
+type HosSearchFilters = {
+  employeeId: string;
+  name: string;
+  department: string;
+  year: string;
+  semester: "" | "S1" | "S2";
+};
+
 type MockRequest = {
   id: string;
   studentId: string;
@@ -120,22 +130,6 @@ function workloadModalNotes(row: Pick<MockRequest, "notes" | "description">) {
 
 function requestReasonText(row: Pick<MockRequest, "requestReason" | "description">) {
   return row.requestReason?.trim() || extractRequestReason(row.description ?? "").trim();
-}
-
-/** Last name, first name, or full name (substring or order-independent tokens; commas as spaces). */
-function workloadNameSearchMatches(recordName: string, queryRaw: string): boolean {
-  const q = queryRaw.trim().toLowerCase();
-  if (!q) return true;
-  const norm = recordName
-    .toLowerCase()
-    .replace(/,/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!norm) return false;
-  if (norm.includes(q)) return true;
-  const qTokens = q.split(/\s+/).filter(Boolean);
-  const parts = norm.split(" ").filter(Boolean);
-  return qTokens.every((t) => parts.some((p) => p.includes(t)));
 }
 
 function shortDepartmentName(department: string) {
@@ -292,9 +286,7 @@ export default function HeadofSchool() {
   const pageSize = 10; // Items per page
   const [submitting, setSubmitting] = useState(false);
 
-  const [statusFilter, setStatusFilter] = useState<
-    "all" | "pending" | "approved" | "rejected"
-  >("pending");
+  const [statusFilter, setStatusFilter] = useState<HosStatusFilter>("pending");
 
   const [popup, setPopup] = useState<{
     open: boolean;
@@ -318,7 +310,7 @@ export default function HeadofSchool() {
   const [searchDepartmentInput, setSearchDepartmentInput] = useState("");
   const [searchYearInput, setSearchYearInput] = useState("");
   const [searchSemesterInput, setSearchSemesterInput] = useState<"" | "S1" | "S2">("");
-  const [searchFilters, setSearchFilters] = useState({
+  const [searchFilters, setSearchFilters] = useState<HosSearchFilters>({
     employeeId: "",
     name: "",
     department: "",
@@ -375,6 +367,20 @@ export default function HeadofSchool() {
     department: "All Departments",
   });
 
+  function buildWorkloadRequestParams(status: HosStatusFilter, filters: HosSearchFilters) {
+    const params: Record<string, string> = {
+      status,
+      page: "1",
+      pageSize: "100",
+    };
+    if (filters.employeeId) params.staffId = filters.employeeId;
+    if (filters.name) params.name = filters.name;
+    if (filters.department) params.department = filters.department;
+    if (filters.year) params.year = filters.year;
+    if (filters.semester) params.semester = filters.semester;
+    return params;
+  }
+
   const availableDepartments: AssignDepartment[] = [
     "Physics",
     "Mathematics & Statistics",
@@ -425,7 +431,7 @@ export default function HeadofSchool() {
       setLoading(true);
       try {
         const [workloadRes, reportsRes, staffRes, assignmentRes, analyticsRes] = await Promise.all([
-          fetchHosWorkloadRequests({ status: "all", page: "1", pageSize: "100" }),
+          fetchHosWorkloadRequests(buildWorkloadRequestParams(statusFilter, searchFilters)),
           fetchHosSemesterReports(),
           fetchHosStaffDirectory({ page: "1", pageSize: "100" }),
           fetchHosRoleAssignments(),
@@ -492,7 +498,7 @@ export default function HeadofSchool() {
   }
 
   async function refreshWorkloads() {
-    const workloadRes = await fetchHosWorkloadRequests({ status: "all", page: "1", pageSize: "100" });
+    const workloadRes = await fetchHosWorkloadRequests(buildWorkloadRequestParams(statusFilter, searchFilters));
     setPending(workloadRes.items.map(mapWorkloadRow));
     const reportsRes = await fetchHosSemesterReports();
     setHosSemesterReports(reportsRes.items);
@@ -513,59 +519,7 @@ export default function HeadofSchool() {
     [pending]
   );
 
-  const itemsForFilter = useMemo(() => {
-    const byStatus =
-      statusFilter === "all"
-        ? pending
-        : pending.filter((it) => it.status === statusFilter);
-
-    const hasSearchFilter = Object.values(searchFilters).some((value) => value);
-    if (!hasSearchFilter) return byStatus;
-
-    return byStatus.filter((it) => {
-      if (
-        searchFilters.employeeId &&
-        !it.studentId.toLowerCase().includes(searchFilters.employeeId)
-      ) {
-        return false;
-      }
-
-      if (searchFilters.name && !workloadNameSearchMatches(it.name, searchFilters.name)) {
-        return false;
-      }
-
-      if (searchFilters.department) {
-        const departmentText = it.department.toLowerCase();
-        const normalizedSearch = searchFilters.department.replace("school", "").trim();
-        if (!departmentText.includes(searchFilters.department) && (!normalizedSearch || !departmentText.includes(normalizedSearch))) {
-          return false;
-        }
-      }
-
-      const submittedText = formatSubmittedTime(it.submittedAt);
-      const submittedDate = new Date(submittedText.replace(" ", "T"));
-      const hasValidSubmittedDate = !Number.isNaN(submittedDate.getTime());
-      const selectedYear = Number(searchFilters.year);
-
-      if (searchFilters.year && Number.isFinite(selectedYear) && hasValidSubmittedDate) {
-        if (searchFilters.semester === "s1") {
-          // S1: [YYYY-01-01, YYYY-07-01)
-          const s1Start = new Date(selectedYear, 0, 1);
-          const s1End = new Date(selectedYear, 6, 1);
-          if (!(submittedDate >= s1Start && submittedDate < s1End)) return false;
-        } else if (searchFilters.semester === "s2") {
-          // S2: [YYYY-07-01, YYYY+1-01-01)
-          const s2Start = new Date(selectedYear, 6, 1);
-          const s2End = new Date(selectedYear + 1, 0, 1);
-          if (!(submittedDate >= s2Start && submittedDate < s2End)) return false;
-        } else if (submittedDate.getFullYear() !== selectedYear) {
-          return false;
-        }
-      }
-
-      return it.name.trim().length > 0;
-    });
-  }, [pending, statusFilter, searchFilters]);
+  const itemsForFilter = pending;
   const adminSearchResults = useMemo(() => {
     const hasFilter = Object.values(adminSearchFilters).some((value) => value);
     if (!hasFilter) return assignablePeople;
@@ -809,25 +763,60 @@ export default function HeadofSchool() {
 
 
   function handleSearch() {
-    setSearchFilters({
+    const nextFilters: HosSearchFilters = {
       employeeId: searchEmployeeIdInput.trim().toLowerCase(),
       name: searchNameInput.trim().toLowerCase(),
       department: searchDepartmentInput.trim().toLowerCase(),
       year: searchYearInput.trim().toLowerCase(),
-      semester: searchSemesterInput.trim().toLowerCase(),
-    });
+      semester: searchSemesterInput,
+    };
+    setSearchFilters(nextFilters);
     setPage(1);
     setSelectedIds(new Set());
     setDetailsOpen(false);
     setDetailsItem(null);
+    void fetchHosWorkloadRequests(buildWorkloadRequestParams(statusFilter, nextFilters)).then((res) => {
+      setPending(res.items.map(mapWorkloadRow));
+    });
   }
 
-  function handleAdminSearch() {
-    setAdminSearchFilters({
+  function applyStatusFilter(nextStatus: HosStatusFilter) {
+    setStatusFilter(nextStatus);
+    setPage(1);
+    setSelectedIds(new Set());
+    setDetailsOpen(false);
+    setDetailsItem(null);
+    void fetchHosWorkloadRequests(buildWorkloadRequestParams(nextStatus, searchFilters)).then((res) => {
+      setPending(res.items.map(mapWorkloadRow));
+    });
+  }
+
+  async function handleAdminSearch() {
+    const nextFilters = {
       firstName: adminSearchFirstNameInput.trim().toLowerCase(),
       lastName: adminSearchLastNameInput.trim().toLowerCase(),
       staffId: adminSearchStaffIdInput.trim().toLowerCase(),
-    });
+    };
+    setAdminSearchFilters(nextFilters);
+    const params: Record<string, string> = { page: "1", pageSize: "100" };
+    if (nextFilters.firstName) params.firstName = nextFilters.firstName;
+    if (nextFilters.lastName) params.lastName = nextFilters.lastName;
+    if (nextFilters.staffId) params.staffId = nextFilters.staffId;
+    const staffRes = await fetchHosStaffDirectory(params);
+    setAssignablePeople(
+      staffRes.items.map((person, idx) => ({
+        id: idx + 1,
+        staffId: person.staffId,
+        firstName: person.firstName,
+        lastName: person.lastName,
+        email: person.email,
+        title: person.title,
+        currentDepartment: person.currentDepartment,
+        isActive: person.isActive,
+        isNewEmployee: person.isNewEmployee,
+        notes: person.notes,
+      }))
+    );
   }
 
   function handlePersonDepartmentChange(personId: number, nextDepartment: string) {
@@ -1378,13 +1367,7 @@ export default function HeadofSchool() {
                   <div className="flex flex-wrap items-center justify-start gap-4">
                     <button
                       type="button"
-                      onClick={() => {
-                        setStatusFilter("all");
-                        setSelectedIds(new Set());
-                        setPage(1);
-                        setDetailsOpen(false);
-                        setDetailsItem(null);
-                      }}
+                      onClick={() => applyStatusFilter("all")}
                       className={`rounded-md border px-5 py-2 text-base font-semibold ${
                         statusFilter === "all"
                           ? "border-[#2f4d9c] bg-[#2f4d9c] text-white"
@@ -1395,13 +1378,7 @@ export default function HeadofSchool() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        setStatusFilter("pending");
-                        setSelectedIds(new Set());
-                        setPage(1);
-                        setDetailsOpen(false);
-                        setDetailsItem(null);
-                      }}
+                      onClick={() => applyStatusFilter("pending")}
                       className={`relative rounded-md border px-5 py-2 text-base font-semibold ${
                         statusFilter === "pending"
                           ? "border-[#d97706] bg-[#d97706] text-white"
@@ -1417,13 +1394,7 @@ export default function HeadofSchool() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        setStatusFilter("approved");
-                        setSelectedIds(new Set());
-                        setPage(1);
-                        setDetailsOpen(false);
-                        setDetailsItem(null);
-                      }}
+                      onClick={() => applyStatusFilter("approved")}
                       className={`rounded-md border px-5 py-2 text-base font-semibold ${
                         statusFilter === "approved"
                           ? "border-[#16a34a] bg-[#16a34a] text-white"
@@ -1434,13 +1405,7 @@ export default function HeadofSchool() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        setStatusFilter("rejected");
-                        setSelectedIds(new Set());
-                        setPage(1);
-                        setDetailsOpen(false);
-                        setDetailsItem(null);
-                      }}
+                      onClick={() => applyStatusFilter("rejected")}
                       className={`rounded-md border px-5 py-2 text-base font-semibold ${
                         statusFilter === "rejected"
                           ? "border-[#dc2626] bg-[#dc2626] text-white"

--- a/frontend/src/pages/Supervisor.tsx
+++ b/frontend/src/pages/Supervisor.tsx
@@ -104,6 +104,15 @@ type HodWorkloadListResponse = {
   };
 };
 
+type HodStatusFilter = "all" | "pending" | "approved" | "rejected";
+
+type HodSearchFilters = {
+  employeeId: string;
+  name: string;
+  year: string;
+  semester: "" | "S1" | "S2";
+};
+
 type HodWorkloadDetailPayload = {
   id: string;
   staffId: string;
@@ -317,9 +326,7 @@ export default function Supervisor() {
   const pageSize = 10; // Items per page
   const [submitting, setSubmitting] = useState(false);
 
-  const [statusFilter, setStatusFilter] = useState<
-    "all" | "pending" | "approved" | "rejected"
-  >("pending");
+  const [statusFilter, setStatusFilter] = useState<HodStatusFilter>("pending");
 
   const [popup, setPopup] = useState<{
     open: boolean;
@@ -341,7 +348,7 @@ export default function Supervisor() {
   const [searchNameInput, setSearchNameInput] = useState("");
   const [searchYearInput, setSearchYearInput] = useState("");
   const [searchSemesterInput, setSearchSemesterInput] = useState<"" | "S1" | "S2">("");
-  const [searchFilters, setSearchFilters] = useState({
+  const [searchFilters, setSearchFilters] = useState<HodSearchFilters>({
     employeeId: "",
     name: "",
     year: "",
@@ -391,11 +398,19 @@ export default function Supervisor() {
     return hodAnnualReports.slice(start, start + hodReportsPerPage);
   }, [hodAnnualReports, hodReportInboxPage]);
 
-  async function loadHodRequests() {
+  async function loadHodRequests(options?: { status?: HodStatusFilter; filters?: HodSearchFilters }) {
     setLoading(true);
     setPageError("");
     try {
-      const response = await apiJson<HodWorkloadListResponse>("/api/hod/workload-requests/?page_size=200");
+      const params = new URLSearchParams({ page_size: "100" });
+      const nextStatus = options?.status ?? statusFilter;
+      const nextFilters = options?.filters ?? searchFilters;
+      if (nextStatus !== "all") params.set("status", nextStatus);
+      if (nextFilters.employeeId) params.set("staffId", nextFilters.employeeId);
+      if (nextFilters.name) params.set("name", nextFilters.name);
+      if (nextFilters.year) params.set("year", nextFilters.year);
+      if (nextFilters.semester) params.set("semester", nextFilters.semester);
+      const response = await apiJson<HodWorkloadListResponse>(`/api/hod/workload-requests/?${params.toString()}`);
       setPending((response.items ?? []).map(mapHodRowToRequest));
     } catch (error) {
       if (!isAbortError(error)) {
@@ -517,61 +532,7 @@ export default function Supervisor() {
     setHodReportInboxPage((prev) => Math.min(Math.max(1, prev), total));
   }, [hodAnnualReports.length]);
 
-  const itemsForFilter = useMemo(() => {
-    const byStatus =
-      statusFilter === "all"
-        ? pending
-        : pending.filter((it) => it.status === statusFilter);
-
-    const hasSearchFilter = Object.values(searchFilters).some((value) => value);
-    if (!hasSearchFilter) return byStatus;
-
-    return byStatus.filter((it) => {
-      const fullName = it.name.toLowerCase();
-      const nameParts = it.name.trim().toLowerCase().split(/\s+/);
-      const firstName = nameParts[0] || "";
-      const lastName = nameParts[nameParts.length - 1] || "";
-
-      if (
-        searchFilters.employeeId &&
-        !it.studentId.toLowerCase().includes(searchFilters.employeeId)
-      ) {
-        return false;
-      }
-
-      if (searchFilters.name) {
-        const q = searchFilters.name;
-        const matchByFull = fullName.includes(q);
-        const matchByFirst = firstName.includes(q);
-        const matchByLast = lastName.includes(q);
-        const matchByReversed = `${lastName} ${firstName}`.includes(q);
-        if (!(matchByFull || matchByFirst || matchByLast || matchByReversed)) return false;
-      }
-
-      const submittedText = submittedAtDisplay(it);
-      const submittedDate = new Date(submittedText.replace(" ", "T"));
-      const hasValidSubmittedDate = !Number.isNaN(submittedDate.getTime());
-      const selectedYear = Number(searchFilters.year);
-
-      if (searchFilters.year && Number.isFinite(selectedYear) && hasValidSubmittedDate) {
-        if (searchFilters.semester === "s1") {
-          // S1: [YYYY-01-01, YYYY-07-01)
-          const s1Start = new Date(selectedYear, 0, 1);
-          const s1End = new Date(selectedYear, 6, 1);
-          if (!(submittedDate >= s1Start && submittedDate < s1End)) return false;
-        } else if (searchFilters.semester === "s2") {
-          // S2: [YYYY-07-01, YYYY+1-01-01)
-          const s2Start = new Date(selectedYear, 6, 1);
-          const s2End = new Date(selectedYear + 1, 0, 1);
-          if (!(submittedDate >= s2Start && submittedDate < s2End)) return false;
-        } else if (submittedDate.getFullYear() !== selectedYear) {
-          return false;
-        }
-      }
-
-      return fullName.length > 0;
-    });
-  }, [pending, statusFilter, searchFilters]);
+  const itemsForFilter = pending;
 
   const totalPages = Math.max(1, Math.ceil(itemsForFilter.length / pageSize));
   const pageItems = useMemo(() => {
@@ -673,16 +634,27 @@ export default function Supervisor() {
 
 
   function handleSearch() {
-    setSearchFilters({
+    const nextFilters: HodSearchFilters = {
       employeeId: searchEmployeeIdInput.trim().toLowerCase(),
       name: searchNameInput.trim().toLowerCase(),
       year: searchYearInput.trim().toLowerCase(),
-      semester: searchSemesterInput.trim().toLowerCase(),
-    });
+      semester: searchSemesterInput,
+    };
+    setSearchFilters(nextFilters);
     setPage(1);
     setSelectedIds(new Set());
     setDetailsOpen(false);
     setDetailsItem(null);
+    void loadHodRequests({ status: statusFilter, filters: nextFilters });
+  }
+
+  function applyStatusFilter(nextStatus: HodStatusFilter) {
+    setStatusFilter(nextStatus);
+    setSelectedIds(new Set());
+    setPage(1);
+    setDetailsOpen(false);
+    setDetailsItem(null);
+    void loadHodRequests({ status: nextStatus, filters: searchFilters });
   }
 
   async function openDetails(item: MockRequest) {
@@ -957,13 +929,7 @@ export default function Supervisor() {
                 <div className="flex flex-wrap items-center justify-start gap-4">
                 <button
                   type="button"
-                  onClick={() => {
-                    setStatusFilter("all");
-                    setSelectedIds(new Set());
-                    setPage(1);
-                    setDetailsOpen(false);
-                    setDetailsItem(null);
-                  }}
+                  onClick={() => applyStatusFilter("all")}
                   className={`rounded-md border px-5 py-2 text-base font-semibold ${
                     statusFilter === "all"
                       ? "border-[#2f4d9c] bg-[#2f4d9c] text-white"
@@ -975,13 +941,7 @@ export default function Supervisor() {
 
                 <button
                   type="button"
-                  onClick={() => {
-                    setStatusFilter("pending");
-                    setSelectedIds(new Set());
-                    setPage(1);
-                    setDetailsOpen(false);
-                    setDetailsItem(null);
-                  }}
+                  onClick={() => applyStatusFilter("pending")}
                   className={`relative rounded-md border px-5 py-2 text-base font-semibold ${
                     statusFilter === "pending"
                       ? "border-[#d97706] bg-[#d97706] text-white"
@@ -998,13 +958,7 @@ export default function Supervisor() {
 
                 <button
                   type="button"
-                  onClick={() => {
-                    setStatusFilter("approved");
-                    setSelectedIds(new Set());
-                    setPage(1);
-                    setDetailsOpen(false);
-                    setDetailsItem(null);
-                  }}
+                  onClick={() => applyStatusFilter("approved")}
                   className={`rounded-md border px-5 py-2 text-base font-semibold ${
                     statusFilter === "approved"
                       ? "border-[#16a34a] bg-[#16a34a] text-white"
@@ -1016,13 +970,7 @@ export default function Supervisor() {
 
                 <button
                   type="button"
-                  onClick={() => {
-                    setStatusFilter("rejected");
-                    setSelectedIds(new Set());
-                    setPage(1);
-                    setDetailsOpen(false);
-                    setDetailsItem(null);
-                  }}
+                  onClick={() => applyStatusFilter("rejected")}
                   className={`rounded-md border px-5 py-2 text-base font-semibold ${
                     statusFilter === "rejected"
                       ? "border-[#dc2626] bg-[#dc2626] text-white"


### PR DESCRIPTION
## Summary
- Route Academic, HoD, and HoS workload search/status filters through backend list endpoints instead of filtering only frontend batches
- Query backend staff-directory endpoints for HoS and School Ops staff search
- Connect School Ops Export Excel to the backend workbook endpoint and load School Ops visualization department stats/trends from the database

## Validation
- npm run build (passes with existing warnings)
- python manage.py check
- Docker DB smoke: 2026 S1 filtered counts Academic=1, HoD=1, School Ops=5, HoS=3
- Excel endpoint smoke returned workbook MIME type for Academic, HoD, School Ops, and HoS